### PR TITLE
Updated seL4 and CAmkES api usage

### DIFF
--- a/models/Minitower/components/VM/src/main.c
+++ b/models/Minitower/components/VM/src/main.c
@@ -371,7 +371,7 @@ main_continued(void)
         seL4_MessageInfo_t tag;
         seL4_Word sender_badge;
 
-        tag = seL4_Wait(_fault_endpoint, &sender_badge);
+        tag = seL4_Recv(_fault_endpoint, &sender_badge);
         if (sender_badge == 0) {
             seL4_Word label;
             label = seL4_MessageInfo_get_label(tag);

--- a/models/Trusted_Build_Test/udp/templates/global-endpoint.template.c
+++ b/models/Trusted_Build_Test/udp/templates/global-endpoint.template.c
@@ -32,27 +32,27 @@
 /*- endif -*/
 /*- set badge = _badge.pop() -*/
 
-/*- set stash_name = "%s_global_aep" % (name) -*/
+/*- set stash_name = "%s_global_notification" % (name) -*/
 
 /*# Check the global stash for our endpoint #*/
-/*- set maybe_aep = _pop(stash_name) -*/
-/*- set _aep_object = [] -*/
+/*- set maybe_notification = _pop(stash_name) -*/
+/*- set _notification_object = [] -*/
 
 /*# Create the endpoint if we need to #*/
-/*- if maybe_aep is none -*/
-    /*- set aep_object = alloc_obj(name, seL4_AsyncEndpointObject) -*/
-    /*- do _aep_object.append(aep_object) -*/
+/*- if maybe_notification is none -*/
+    /*- set notification_object = alloc_obj(name, seL4_Notification) -*/
+    /*- do _notification_object.append(notification_object) -*/
 /*- else -*/
-    /*- do _aep_object.append(maybe_aep) -*/
+    /*- do _notification_object.append(maybe_notification) -*/
 /*- endif -*/
 
-/*- set aep_object = _aep_object.pop() -*/
+/*- set notification_object = _notification_object.pop() -*/
 
 /*# Put it back into the stash #*/
-/*- do _stash(stash_name, aep_object) -*/
+/*- do _stash(stash_name, notification_object) -*/
 
 /*# Create the badged endpoint #*/
-/*- set aep = alloc_cap('%s_%s_aep_object_cap' % (name, bade), aep_object, read=is_reader, write=True) -*/
-/*- do cap_space.cnode[aep].set_badge(int(badge, 10)) -*/
+/*- set notification = alloc_cap('%s_%s_notification_object_cap' % (name, bade), notification_object, read=is_reader, write=True) -*/
+/*- do cap_space.cnode[notification].set_badge(int(badge, 10)) -*/
 
-/*- do stash('aep', aep) -*/
+/*- do stash('notification', notification) -*/

--- a/models/Trusted_Build_Test/udp/templates/seL4Ethdriver-from.template.c
+++ b/models/Trusted_Build_Test/udp/templates/seL4Ethdriver-from.template.c
@@ -14,8 +14,8 @@
 /*- set instance = me.from_instance.name -*/
 /*- set interface = me.from_interface.name -*/
 /*- include 'global-endpoint.template.c' -*/
-/*- set aep = pop('aep') -*/
+/*- set notification = pop('notification') -*/
 
-seL4_CPtr /*? me.from_interface.name ?*/_aep(void) {
-    return /*? aep ?*/;
+seL4_CPtr /*? me.from_interface.name ?*/_notification(void) {
+    return /*? notification ?*/;
 }

--- a/models/Trusted_Build_Test/udp/templates/seL4Ethdriver-to.template.c
+++ b/models/Trusted_Build_Test/udp/templates/seL4Ethdriver-to.template.c
@@ -22,7 +22,7 @@
             /*- set instance = c.from_instance.name -*/
             /*- set interface = c.from_interface.name -*/
             /*- include 'global-endpoint.template.c' -*/
-            /*- set aep = pop('aep') -*/
+            /*- set notification = pop('notification') -*/
             /*- set _badge = [] -*/
             /*- set _mac = [] -*/
             /*- for s in configuration.settings -*/
@@ -40,7 +40,7 @@
             /*- set badge = _badge.pop() -*/
             /*- set mac = _mac.pop() -*/
             void /*? me.to_interface.name ?*/_emit_/*? badge ?*/(void) {
-                seL4_Notify(/*? aep ?*/, 0);
+                seL4_Signal(/*? notification ?*/, 0);
             }
             /*- do badges.append(badge) -*/
             /*- do macs.append( (badge, mac) ) -*/


### PR DESCRIPTION
References to "aep" or "async" endpoint are renamed to "notification".
seL4_Wait is renamed to seL4_Recv. seL4_Notify is renamed to
seL4_Signal.