### PR TITLE
Add optional display in counterexamples of real values as decimal

### DIFF
--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/preferences/AgreePreferencePage.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/preferences/AgreePreferencePage.java
@@ -63,6 +63,7 @@ public class AgreePreferencePage extends FieldEditorPreferencePage implements IW
     private BooleanFieldEditor inductiveCounterexampleFieldEditor;
     private BooleanFieldEditor noKInductionEditor;
     private BooleanFieldEditor smoothingFieldEditor;
+    private BooleanFieldEditor displayCounterexampleDecimalFormEditor;
     private BooleanFieldEditor generalizeFieldEditor;
     private NonNegativeIntegerFieldEditor depthFieldEditor;
     private NonNegativeIntegerFieldEditor timeoutFieldEditor;
@@ -102,6 +103,11 @@ public class AgreePreferencePage extends FieldEditorPreferencePage implements IW
                 "Generate smooth counterexamples (minimal number of input value changes)",
                 getFieldEditorParent());
         addField(smoothingFieldEditor);
+
+        displayCounterexampleDecimalFormEditor = new BooleanFieldEditor(PreferenceConstants.PREF_DISPLAY_DECIMAL_CEX,
+                "Display real values as decimal in counterexamples",
+                getFieldEditorParent());
+        addField(displayCounterexampleDecimalFormEditor);
 
         generalizeFieldEditor = new BooleanFieldEditor(PreferenceConstants.PREF_BLAME_CEX,
                 "Generate blamed counterexamples (generalized counter examples)", getFieldEditorParent());

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/preferences/PreferenceConstants.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/preferences/PreferenceConstants.java
@@ -10,6 +10,8 @@ public class PreferenceConstants {
 
     public static final String PREF_SMOOTH_CEX = "smoothCounterexamples";
 
+    public static final String PREF_DISPLAY_DECIMAL_CEX = "displayCounterexamplesAsDecimal";
+
     public static final String PREF_BLAME_CEX = "blameCounterexamples";
 
     public static final String PREF_NO_KINDUCTION = "disableKInduction";

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/preferences/PreferenceInitializer.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/preferences/PreferenceInitializer.java
@@ -16,6 +16,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
         store.setDefault(PreferenceConstants.PREF_SOLVER, PreferenceConstants.SOLVER_SMTINTERPOL);
         store.setDefault(PreferenceConstants.PREF_INDUCT_CEX, true);
         store.setDefault(PreferenceConstants.PREF_SMOOTH_CEX, false);
+        store.setDefault(PreferenceConstants.PREF_DISPLAY_DECIMAL_CEX, false);
         store.setDefault(PreferenceConstants.PREF_DEPTH, 200);
         store.setDefault(PreferenceConstants.PREF_TIMEOUT, 100);
         store.setDefault(PreferenceConstants.PREF_CONSIST_DEPTH, 1);

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/views/AgreeCounterexampleStepLabelProvider.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/views/AgreeCounterexampleStepLabelProvider.java
@@ -1,0 +1,71 @@
+package com.rockwellcollins.atc.agree.analysis.views;
+
+import com.rockwellcollins.atc.agree.analysis.Activator;
+import com.rockwellcollins.atc.agree.analysis.preferences.PreferenceConstants;
+
+import jkind.api.ui.counterexample.CounterexampleStepLabelProvider;
+import jkind.api.ui.counterexample.SignalGroup;
+import jkind.lustre.values.RealValue;
+import jkind.lustre.values.Value;
+
+public class AgreeCounterexampleStepLabelProvider extends CounterexampleStepLabelProvider {
+
+	private final int step;
+
+	private final boolean displayAsDecimal;
+
+	public AgreeCounterexampleStepLabelProvider(int step) {
+		super(step);
+		this.step = step;
+		this.displayAsDecimal = Activator.getDefault().getPreferenceStore()
+				.getBoolean(PreferenceConstants.PREF_DISPLAY_DECIMAL_CEX);
+	}
+
+	@Override
+	public String getText(Object element) {
+		if (element instanceof SignalGroup) {
+			SignalGroup group = (SignalGroup) element;
+			if (group.isSingleton()) {
+				Value value = group.getSignals().get(0).getValue(step);
+				if (value == null) {
+					return "";
+				} else if (value instanceof RealValue && displayAsDecimal) {
+					return ((RealValue) value).value.toTruncatedDecimal(12, "...");
+				} else {
+					return value.toString();
+				}
+			}
+		}
+
+		return "";
+	}
+
+	@Override
+	public String getToolTipText(Object element) {
+		if (element instanceof SignalGroup) {
+			SignalGroup group = (SignalGroup) element;
+			if (group.isSingleton()) {
+				Value value = group.getSignals().get(0).getValue(step);
+				if (value == null) {
+					return null;
+				} else if (value instanceof RealValue && displayAsDecimal) {
+					RealValue rv = (RealValue) value;
+					return rv.toString();
+				}
+			}
+		}
+
+		return null;
+	}
+
+	@Override
+	public int getToolTipDisplayDelayTime(Object object) {
+		return 500;
+	}
+
+	@Override
+	public int getToolTipTimeDisplayed(Object object) {
+		return 10000;
+	}
+
+}

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/views/AgreeCounterexampleTreeViewer.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/views/AgreeCounterexampleTreeViewer.java
@@ -1,0 +1,76 @@
+package com.rockwellcollins.atc.agree.analysis.views;
+
+import jkind.api.ui.counterexample.CounterexampleContentProvider;
+import jkind.api.ui.counterexample.CounterexampleNameLabelProvider;
+import jkind.results.Counterexample;
+import jkind.results.layout.Layout;
+
+import org.eclipse.jface.layout.TreeColumnLayout;
+import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
+import org.eclipse.jface.viewers.ColumnWeightData;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.TreeViewerColumn;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+
+public class AgreeCounterexampleTreeViewer {
+
+	protected TreeViewer treeViewer;
+	protected final Composite composite;
+
+	public AgreeCounterexampleTreeViewer(Composite parent) {
+			this.composite = new Composite(parent, SWT.None);
+		}
+
+	public void setFocus() {
+		if (treeViewer != null) {
+			treeViewer.getTree().setFocus();
+		}
+	}
+
+	public void setInput(Counterexample cex, Layout layout) {
+		initializeTreeViewer(layout);
+		createColumns(cex);
+		treeViewer.setInput(cex);
+		composite.layout(true);
+	}
+
+	private void initializeTreeViewer(Layout layout) {
+		if (treeViewer != null) {
+			treeViewer.getControl().dispose();
+		}
+		treeViewer = new TreeViewer(composite, SWT.MULTI | SWT.FULL_SELECTION);
+
+		treeViewer.setContentProvider(new CounterexampleContentProvider(layout));
+		treeViewer.getTree().setHeaderVisible(true);
+		treeViewer.getTree().setLinesVisible(true);
+	}
+
+	private void createColumns(Counterexample cex) {
+		TreeColumnLayout layout = new TreeColumnLayout();
+		composite.setLayout(layout);
+		createNameColumn(layout);
+		for (int i = 0; i < cex.getLength(); i++) {
+			createStepColumn(i, layout);
+		}
+	}
+
+	private void createNameColumn(TreeColumnLayout layout) {
+		TreeViewerColumn nameCol = new TreeViewerColumn(treeViewer, SWT.None);
+		nameCol.getColumn().setText("Name");
+		nameCol.setLabelProvider(new CounterexampleNameLabelProvider());
+		layout.setColumnData(nameCol.getColumn(), new ColumnWeightData(10, 200));
+	}
+
+	private void createStepColumn(int i, TreeColumnLayout layout) {
+		TreeViewerColumn stepCol = new TreeViewerColumn(treeViewer, SWT.None);
+		stepCol.getColumn().setText("Step " + (i + 1));
+		ColumnViewerToolTipSupport.enableFor(stepCol.getViewer());
+		stepCol.setLabelProvider(new AgreeCounterexampleStepLabelProvider(i));
+		layout.setColumnData(stepCol.getColumn(), new ColumnWeightData(1, 50));
+	}
+
+	public TreeViewer getTreeViewer() {
+		return treeViewer;
+	}
+}

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/views/AgreeCounterexampleView.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/views/AgreeCounterexampleView.java
@@ -3,7 +3,6 @@ package com.rockwellcollins.atc.agree.analysis.views;
 import java.util.Map;
 import java.util.Stack;
 
-import jkind.api.ui.counterexample.CounterexampleTreeViewer;
 import jkind.api.ui.counterexample.SignalGroup;
 import jkind.results.Counterexample;
 import jkind.results.layout.Layout;
@@ -23,12 +22,12 @@ public class AgreeCounterexampleView extends ViewPart {
     public static final String ID = "com.rockwellcollins.atc.agree.analysis.views.agreeCounterexampleView";
     private static final GlobalURIEditorOpener globalURIEditorOpener = AgreeUtils.getGlobalURIEditorOpener();
 
-    private CounterexampleTreeViewer tree;
+    private AgreeCounterexampleTreeViewer tree;
     private Map<String, EObject> refMap;
 
     @Override
     public void createPartControl(Composite parent) {
-        tree = new CounterexampleTreeViewer(parent);
+        tree = new AgreeCounterexampleTreeViewer(parent);
     }
 
     @Override


### PR DESCRIPTION
Add the option in the counterexample view to display real values as in the truncated decimal form provided by the JKind API.  If this display is enabled, the full-precision rational value is available by hovering the mouse over the decimal value.

Also adds a preference page option to enable the feature if checked.  Defaults to unchecked.