### PR TITLE
Develop ivc for consistency

### DIFF
--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/lustre/visitors/RenamingVisitor.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/lustre/visitors/RenamingVisitor.java
@@ -80,7 +80,10 @@ public class RenamingVisitor extends AstIterVisitor{
             String refStr = getReferenceStr(var);
 
             if (isMainNode && var.reference != null) {
-                if (var.reference instanceof AssumeStatement && category != null && category.equals("")) {
+                // TODO: the means of detecting whether this is a consistency analysis is a hack. Fix it.
+                if ((var.reference instanceof AssumeStatement
+                        || (nodeName.contains("consistency") && var.reference instanceof GuaranteeStatement))
+                        && category != null && category.equals("")) {
                     renaming.addSupportRename(var.id, var.id);
                     renaming.addSupportRefString(var.id, refStr);
                     renaming.getRefMap().put(refStr, var.reference);

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/translation/LustreAstBuilder.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/translation/LustreAstBuilder.java
@@ -15,6 +15,7 @@ import org.osate.aadl2.impl.EventDataPortImpl;
 import org.eclipse.xtext.util.Pair;
 
 import com.rockwellcollins.atc.agree.agree.Arg;
+import com.rockwellcollins.atc.agree.agree.AssertStatement;
 import com.rockwellcollins.atc.agree.agree.AssumeStatement;
 import com.rockwellcollins.atc.agree.agree.EqStatement;
 import com.rockwellcollins.atc.agree.agree.InputStatement;
@@ -355,7 +356,7 @@ public class LustreAstBuilder {
 		int stuffAssumptionIndex = 0;
 		for (AgreeStatement assumption : agreeNode.assumptions) {
 			AgreeVar stuffAssumptionVar = new AgreeVar(stuffPrefix + assumeSuffix + stuffAssumptionIndex++,
-					NamedType.BOOL, assumption, null, null);
+					NamedType.BOOL, assumption.reference, agreeNode.compInst, null);
 			locals.add(stuffAssumptionVar);
 			ivcs.add(stuffAssumptionVar.id);
 			IdExpr stuffAssumptionId = new IdExpr(stuffAssumptionVar.id);
@@ -367,7 +368,7 @@ public class LustreAstBuilder {
 		int stuffGuaranteeIndex = 0;
 		for (AgreeStatement guarantee : agreeNode.guarantees) {
 			AgreeVar stuffGuaranteeVar = new AgreeVar(stuffPrefix + guarSuffix + stuffGuaranteeIndex++,
-					NamedType.BOOL, guarantee, null, null);
+					NamedType.BOOL, guarantee.reference, agreeNode.compInst, null);
 			locals.add(stuffGuaranteeVar);
 			ivcs.add(stuffGuaranteeVar.id);
 			IdExpr stuffGuaranteeId = new IdExpr(stuffGuaranteeVar.id);
@@ -394,9 +395,8 @@ public class LustreAstBuilder {
 		if (withAssertions) {
 			for (AgreeStatement assertion : agreeNode.assertions) {
 				AgreeVar stuffAssertionVar = new AgreeVar(stuffPrefix + assertSuffix + stuffAssertionIndex++,
-						NamedType.BOOL, assertion, null, null);
+						NamedType.BOOL, assertion.reference, null, null);
 				locals.add(stuffAssertionVar);
-				ivcs.add(stuffAssertionVar.id);
 				IdExpr stuffAssertionId = new IdExpr(stuffAssertionVar.id);
 				equations.add(new Equation(stuffAssertionId, assertion.expr));
 
@@ -408,9 +408,8 @@ public class LustreAstBuilder {
 			for (AgreeStatement assertion : agreeNode.assertions) {
 				if (AgreeUtils.referenceIsInContract(assertion.reference, agreeNode.compInst)) {
 					AgreeVar stuffAssertionVar = new AgreeVar(stuffPrefix + assertSuffix + stuffAssertionIndex++,
-							NamedType.BOOL, assertion, null, null);
+							NamedType.BOOL, assertion.reference, null, null);
 					locals.add(stuffAssertionVar);
-					ivcs.add(stuffAssertionVar.id);
 					IdExpr stuffAssertionId = new IdExpr(stuffAssertionVar.id);
 					equations.add(new Equation(stuffAssertionId, assertion.expr));
 

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/translation/LustreAstBuilder.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/translation/LustreAstBuilder.java
@@ -65,6 +65,7 @@ public class LustreAstBuilder {
 	protected static final String guarSuffix = "__GUARANTEE";
 	public static final String assumeSuffix = "__ASSUME";
 	protected static final String lemmaSuffix = "__LEMMA";
+	protected static final String assertSuffix = "__ASSERT";
 	protected static final String historyNodeName = "__HIST";
 	public static final String assumeHistSufix = assumeSuffix + historyNodeName;
 	protected static final String patternPropSuffix = "__PATTERN";
@@ -340,21 +341,39 @@ public class LustreAstBuilder {
 	}
 
 	protected static Node getConsistencyLustreNode(AgreeNode agreeNode, boolean withAssertions) {
+		final String stuffPrefix = "__STUFF";
 
 		List<Expr> assertions = new ArrayList<>();
 		List<VarDecl> locals = new ArrayList<>();
 		List<VarDecl> inputs = new ArrayList<>();
 		List<Equation> equations = new ArrayList<>();
 		List<String> properties = new ArrayList<>();
+		List<String> ivcs = new ArrayList<>();
 
 		Expr stuffConj = new BoolExpr(true);
 
+		int stuffAssumptionIndex = 0;
 		for (AgreeStatement assumption : agreeNode.assumptions) {
-			stuffConj = new BinaryExpr(stuffConj, BinaryOp.AND, assumption.expr);
+			AgreeVar stuffAssumptionVar = new AgreeVar(stuffPrefix + assumeSuffix + stuffAssumptionIndex++,
+					NamedType.BOOL, assumption, null, null);
+			locals.add(stuffAssumptionVar);
+			ivcs.add(stuffAssumptionVar.id);
+			IdExpr stuffAssumptionId = new IdExpr(stuffAssumptionVar.id);
+			equations.add(new Equation(stuffAssumptionId, assumption.expr));
+
+			stuffConj = new BinaryExpr(stuffConj, BinaryOp.AND, stuffAssumptionId);
 		}
 
+		int stuffGuaranteeIndex = 0;
 		for (AgreeStatement guarantee : agreeNode.guarantees) {
-			stuffConj = new BinaryExpr(stuffConj, BinaryOp.AND, guarantee.expr);
+			AgreeVar stuffGuaranteeVar = new AgreeVar(stuffPrefix + guarSuffix + stuffGuaranteeIndex++,
+					NamedType.BOOL, guarantee, null, null);
+			locals.add(stuffGuaranteeVar);
+			ivcs.add(stuffGuaranteeVar.id);
+			IdExpr stuffGuaranteeId = new IdExpr(stuffGuaranteeVar.id);
+			equations.add(new Equation(stuffGuaranteeId, guarantee.expr));
+
+			stuffConj = new BinaryExpr(stuffConj, BinaryOp.AND, stuffGuaranteeId);
 		}
 
 		if (withAssertions) {
@@ -371,17 +390,31 @@ public class LustreAstBuilder {
 		// histConj = new BinaryExpr(histConj, BinaryOp.AND, guarantee.expr);
 		// }
 
+		int stuffAssertionIndex = 0;
 		if (withAssertions) {
 			for (AgreeStatement assertion : agreeNode.assertions) {
-				stuffConj = new BinaryExpr(stuffConj, BinaryOp.AND, assertion.expr);
+				AgreeVar stuffAssertionVar = new AgreeVar(stuffPrefix + assertSuffix + stuffAssertionIndex++,
+						NamedType.BOOL, assertion, null, null);
+				locals.add(stuffAssertionVar);
+				ivcs.add(stuffAssertionVar.id);
+				IdExpr stuffAssertionId = new IdExpr(stuffAssertionVar.id);
+				equations.add(new Equation(stuffAssertionId, assertion.expr));
+
+				stuffConj = new BinaryExpr(stuffConj, BinaryOp.AND, stuffAssertionId);
 			}
 		} else {
 			// perhaps we should break out eq statements into implementation
-			// equations
-			// and type equations. This would clear this up
+			// equations  and type equations. That would clear this up.
 			for (AgreeStatement assertion : agreeNode.assertions) {
 				if (AgreeUtils.referenceIsInContract(assertion.reference, agreeNode.compInst)) {
-					stuffConj = new BinaryExpr(stuffConj, BinaryOp.AND, assertion.expr);
+					AgreeVar stuffAssertionVar = new AgreeVar(stuffPrefix + assertSuffix + stuffAssertionIndex++,
+							NamedType.BOOL, assertion, null, null);
+					locals.add(stuffAssertionVar);
+					ivcs.add(stuffAssertionVar.id);
+					IdExpr stuffAssertionId = new IdExpr(stuffAssertionVar.id);
+					equations.add(new Equation(stuffAssertionId, assertion.expr));
+
+					stuffConj = new BinaryExpr(stuffConj, BinaryOp.AND, stuffAssertionId);
 				}
 			}
 		}
@@ -420,7 +453,7 @@ public class LustreAstBuilder {
 		EObject classifier = agreeNode.compInst.getComponentClassifier();
 
 		AgreeVar countVar = new AgreeVar("__COUNT", NamedType.INT, null, null, null);
-		AgreeVar stuffVar = new AgreeVar("__STUFF", NamedType.BOOL, null, null, null);
+		AgreeVar stuffVar = new AgreeVar(stuffPrefix, NamedType.BOOL, null, null, null);
 		AgreeVar histVar = new AgreeVar("__HIST", NamedType.BOOL, null, null, null);
 		AgreeVar propVar = new AgreeVar("__PROP", NamedType.BOOL, classifier, agreeNode.compInst, null);
 
@@ -460,6 +493,7 @@ public class LustreAstBuilder {
 		builder.addEquations(equations);
 		builder.addProperties(properties);
 		builder.addAssertions(assertions);
+		builder.addIvcs(ivcs);
 
 		Node node = builder.build();
 

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/views/AgreeMenuListener.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/views/AgreeMenuListener.java
@@ -208,7 +208,6 @@ public class AgreeMenuListener implements IMenuListener {
         };
     }
 
-    // Anitha added this displaying view support menu
     private void addViewSupportMenu(IMenuManager manager, AnalysisResult result) {
         IPreferenceStore prefs = Activator.getDefault().getPreferenceStore();
         if (prefs.getString(PreferenceConstants.PREF_MODEL_CHECKER)
@@ -216,17 +215,14 @@ public class AgreeMenuListener implements IMenuListener {
                 && prefs.getBoolean(PreferenceConstants.PREF_SUPPORT)) {
             if (!(result instanceof ConsistencyResult || result instanceof JRealizabilityResult)) {
                 if (result instanceof PropertyResult) {
-                    if (((PropertyResult) result).getStatus().equals(jkind.api.results.Status.VALID)) {
-                        if (!((PropertyResult) result).getParent().getName().contains("consistent")) {
-                            manager.add(addViewSupportConsole("Set of Support", manager, result));
-                        }
+                    if (((PropertyResult) result).getProperty() instanceof ValidProperty) {
+                        manager.add(addViewSupportConsole("Set of Support", manager, result));
                     }
                 }
             }
         }
     }
 
-    // Anitha added this displaying support in console
     private IAction addViewSupportConsole(String text, IMenuManager manager, AnalysisResult result) {
         return new Action(text) {
             public void run() {

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/views/AgreeMenuListener.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/views/AgreeMenuListener.java
@@ -77,6 +77,7 @@ public class AgreeMenuListener implements IMenuListener {
     private final IWorkbenchWindow window;
     private final AnalysisResultTree tree;
     private AgreeResultsLinker linker;
+    private AgreePatternListener patternListener = null;
 
     public AgreeMenuListener(IWorkbenchWindow window, AnalysisResultTree tree) {
         this.window = window;
@@ -243,7 +244,11 @@ public class AgreeMenuListener implements IMenuListener {
                 final Renaming renaming = tempRenaming;
                 showConsole(console);
                 console.clearConsole();
-                console.addPatternMatchListener(new AgreePatternListener(refMap));
+                if (patternListener != null) {
+                    console.removePatternMatchListener(patternListener);
+                }
+                patternListener = new AgreePatternListener(refMap);
+                console.addPatternMatchListener(patternListener);
                 new Thread(new Runnable() {
                     @Override
                     public void run() {


### PR DESCRIPTION
Add generation of IVC data for consistency checks.  This involved adding Lustre variables for IVC assumptions and guarantees.  Also, modifications to enable display of the results in the AGREE UI.

There's still an old bug that causes the hyperlinks from IVC (and all AGREE results) back to the model to be broken when the analysis completes.  This is because the annex model elements containing the referenced specification statements somehow become unlinked from their containing AADL model elements.  Still need to figure out why this is happening.