### PR TITLE
Fix Issue #75: missing variables in counter example views

### DIFF
--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/handlers/VerifyHandler.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/handlers/VerifyHandler.java
@@ -131,9 +131,9 @@ public abstract class VerifyHandler extends AadlHandler {
 				ComponentImplementation ci = cis.get(0);
 				Shell shell = getWindow().getShell();
 				String message = "User selected " + ct.getFullName() + ".\nRunning analysis on " + ci.getFullName()
-						+ " instead.";
+				+ " instead.";
 				shell.getDisplay()
-						.asyncExec(() -> MessageDialog.openInformation(shell, "Analysis information", message));
+				.asyncExec(() -> MessageDialog.openInformation(shell, "Analysis information", message));
 				return ci;
 			} else {
 				throw new AgreeException(
@@ -299,7 +299,7 @@ public abstract class VerifyHandler extends AadlHandler {
 
 		List<String> properties = new ArrayList<>();
 
-		RenamingVisitor.addRenamings(lustreProgram, renaming, layout);
+		RenamingVisitor.addRenamings(lustreProgram, renaming, compInst, layout);
 		addProperties(renaming, properties, mainNode, agreeProgram);
 
 		for (AgreeAutomater aa : automaters) {
@@ -394,31 +394,25 @@ public abstract class VerifyHandler extends AadlHandler {
 		 * otherwise we can get a deadlock condition if the UI tries to lock the document,
 		 * e.g., to pull up hover information.
 		 */
-		getWindow().getShell().getDisplay().asyncExec(new Runnable() {
-			@Override
-			public void run() {
-				try {
-					AgreeResultsView page = (AgreeResultsView) getWindow().getActivePage()
-							.showView(AgreeResultsView.ID);
-					page.setInput(result, linker);
-				} catch (PartInitException e) {
-					e.printStackTrace();
-				}
+		getWindow().getShell().getDisplay().asyncExec(() -> {
+			try {
+				AgreeResultsView page = (AgreeResultsView) getWindow().getActivePage()
+						.showView(AgreeResultsView.ID);
+				page.setInput(result, linker);
+			} catch (PartInitException e) {
+				e.printStackTrace();
 			}
 		});
 	}
 
 	protected void clearView() {
-		getWindow().getShell().getDisplay().syncExec(new Runnable() {
-			@Override
-			public void run() {
-				try {
-					AgreeResultsView page = (AgreeResultsView) getWindow().getActivePage()
-							.showView(AgreeResultsView.ID);
-					page.setInput(new CompositeAnalysisResult("empty"), null);
-				} catch (PartInitException e) {
-					e.printStackTrace();
-				}
+		getWindow().getShell().getDisplay().syncExec(() -> {
+			try {
+				AgreeResultsView page = (AgreeResultsView) getWindow().getActivePage()
+						.showView(AgreeResultsView.ID);
+				page.setInput(new CompositeAnalysisResult("empty"), null);
+			} catch (PartInitException e) {
+				e.printStackTrace();
 			}
 		});
 	}
@@ -487,45 +481,33 @@ public abstract class VerifyHandler extends AadlHandler {
 	}
 
 	private void activateTerminateHandlers(final IProgressMonitor globalMonitor) {
-		getWindow().getShell().getDisplay().syncExec(new Runnable() {
-			@Override
-			public void run() {
-				terminateActivation = handlerService.activateHandler(TERMINATE_ID, new TerminateHandler(monitorRef));
-				terminateAllActivation = handlerService.activateHandler(TERMINATE_ALL_ID,
-						new TerminateHandler(monitorRef, globalMonitor));
-			}
+		getWindow().getShell().getDisplay().syncExec(() -> {
+			terminateActivation = handlerService.activateHandler(TERMINATE_ID, new TerminateHandler(monitorRef));
+			terminateAllActivation = handlerService.activateHandler(TERMINATE_ALL_ID,
+					new TerminateHandler(monitorRef, globalMonitor));
 		});
 	}
 
 	private void deactivateTerminateHandlers() {
-		getWindow().getShell().getDisplay().syncExec(new Runnable() {
-			@Override
-			public void run() {
-				handlerService.deactivateHandler(terminateActivation);
-				handlerService.deactivateHandler(terminateAllActivation);
-			}
+		getWindow().getShell().getDisplay().syncExec(() -> {
+			handlerService.deactivateHandler(terminateActivation);
+			handlerService.deactivateHandler(terminateAllActivation);
 		});
 	}
 
 	private void enableRerunHandler(final Element root) {
-		getWindow().getShell().getDisplay().syncExec(new Runnable() {
-			@Override
-			public void run() {
-				IHandlerService handlerService = getHandlerService();
-				rerunActivation = handlerService.activateHandler(RERUN_ID, new RerunHandler(root, VerifyHandler.this));
-			}
+		getWindow().getShell().getDisplay().syncExec(() -> {
+			IHandlerService handlerService = getHandlerService();
+			rerunActivation = handlerService.activateHandler(RERUN_ID, new RerunHandler(root, VerifyHandler.this));
 		});
 	}
 
 	protected void disableRerunHandler() {
 		if (rerunActivation != null) {
-			getWindow().getShell().getDisplay().syncExec(new Runnable() {
-				@Override
-				public void run() {
-					IHandlerService handlerService = getHandlerService();
-					handlerService.deactivateHandler(rerunActivation);
-					rerunActivation = null;
-				}
+			getWindow().getShell().getDisplay().syncExec(() -> {
+				IHandlerService handlerService = getHandlerService();
+				handlerService.deactivateHandler(rerunActivation);
+				rerunActivation = null;
 			});
 		}
 	}

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/lustre/visitors/RenamingVisitor.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/lustre/visitors/RenamingVisitor.java
@@ -7,6 +7,7 @@ import org.osate.aadl2.DataPort;
 import org.osate.aadl2.EventDataPort;
 import org.osate.aadl2.FeatureGroup;
 import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.instance.ComponentInstance;
 
 import com.rockwellcollins.atc.agree.agree.Arg;
 import com.rockwellcollins.atc.agree.agree.AssertStatement;
@@ -32,18 +33,22 @@ import jkind.lustre.visitors.AstIterVisitor;
 public class RenamingVisitor extends AstIterVisitor {
 
 	private final AgreeRenaming renaming;
+	private final ComponentInstance rootInstance;
 	private final AgreeLayout layout;
 	private final Program program;
 	private boolean isMainNode;
 	private String nodeName;
 
-	public static void addRenamings(Program program, AgreeRenaming renaming, AgreeLayout layout) {
-		RenamingVisitor visitor = new RenamingVisitor(program, renaming, layout);
+	public static void addRenamings(Program program, AgreeRenaming renaming, ComponentInstance rootInstance,
+			AgreeLayout layout) {
+		RenamingVisitor visitor = new RenamingVisitor(program, renaming, rootInstance, layout);
 		visitor.visit(program);
 	}
 
-	private RenamingVisitor(Program program, AgreeRenaming renaming, AgreeLayout layout) {
+	private RenamingVisitor(Program program, AgreeRenaming renaming, ComponentInstance rootInstance,
+			AgreeLayout layout) {
 		this.renaming = renaming;
+		this.rootInstance = rootInstance;
 		this.layout = layout;
 		this.program = program;
 	}
@@ -76,7 +81,7 @@ public class RenamingVisitor extends AstIterVisitor {
 	public Void visit(VarDecl e) {
 		if (e instanceof AgreeVar) {
 			AgreeVar var = (AgreeVar) e;
-			String category = getCategory(var);
+			String category = getCategory(rootInstance, var);
 			String refStr = getReferenceStr(var);
 
 			if (isMainNode && var.reference != null) {
@@ -110,7 +115,7 @@ public class RenamingVisitor extends AstIterVisitor {
 
 	private String getReferenceStr(AgreeVar var) {
 
-		String prefix = getCategory(var);
+		String prefix = getCategory(rootInstance, var);
 		if (prefix == null) {
 			return null;
 		}
@@ -163,11 +168,12 @@ public class RenamingVisitor extends AstIterVisitor {
 		throw new AgreeException("Unhandled reference type: '" + reference.getClass().getName() + "'");
 	}
 
-	public static String getCategory(AgreeVar var) {
+	public static String getCategory(ComponentInstance rootInstance, AgreeVar var) {
 		if (var.compInst == null || var.reference == null) {
 			return null;
 		}
-		return LustreAstBuilder.getRelativeLocation(var.compInst.getInstanceObjectPath());
+		return LustreAstBuilder.getRelativeLocation(rootInstance.getInstanceObjectPath(),
+				var.compInst.getInstanceObjectPath());
 	}
 
 }

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/translation/LustreAstBuilder.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/translation/LustreAstBuilder.java
@@ -494,12 +494,14 @@ public class LustreAstBuilder {
 
 	}
 
-	public static String getRelativeLocation(String location) {
-		int dotIndex = location.indexOf(".");
-		if (dotIndex < 0) {
+	public static String getRelativeLocation(String rootLocation, String location) {
+		if (!location.contains(".") || location.equalsIgnoreCase(rootLocation)) {
 			return "";
 		}
-		return location.substring(dotIndex + 1);
+		if (location.toUpperCase().startsWith(rootLocation.toUpperCase())) {
+			return location.substring(rootLocation.length() + 1);
+		}
+		return "";
 	}
 
 	protected static Equation getHist(IdExpr histId, Expr expr) {

--- a/fm-workbench/simulator/edu.uah.rsesc.aadlsimulator.agree/src/edu/uah/rsesc/aadlsimulator/agree/transformation/AgreeProgramToSimulationProgram.java
+++ b/fm-workbench/simulator/edu.uah.rsesc.aadlsimulator.agree/src/edu/uah/rsesc/aadlsimulator/agree/transformation/AgreeProgramToSimulationProgram.java
@@ -2,66 +2,65 @@
 Copyright (c) 2015, Rockwell Collins.
 Developed with the sponsorship of Defense Advanced Research Projects Agency (DARPA).
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this data, 
-including any software or models in source or binary form, as well as any drawings, specifications, 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this data,
+including any software or models in source or binary form, as well as any drawings, specifications,
 and documentation (collectively "the Data"), to deal in the Data without restriction, including
-without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Data, and to permit persons to whom the Data is furnished to do so, 
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Data, and to permit persons to whom the Data is furnished to do so,
 subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or 
+The above copyright notice and this permission notice shall be included in all copies or
 substantial portions of the Data.
 
-THE DATA IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
-LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS, SPONSORS, DEVELOPERS, CONTRIBUTORS, OR COPYRIGHT HOLDERS BE LIABLE 
-FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
+THE DATA IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS, SPONSORS, DEVELOPERS, CONTRIBUTORS, OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE DATA OR THE USE OR OTHER DEALINGS IN THE DATA.
-*/
+ */
 package edu.uah.rsesc.aadlsimulator.agree.transformation;
 
 import java.util.Map;
 import java.util.Objects;
-
-import jkind.lustre.Program;
-import jkind.lustre.VarDecl;
 
 import org.eclipse.emf.ecore.EObject;
 import org.osate.aadl2.instance.FeatureInstance;
 
 import com.rockwellcollins.atc.agree.analysis.AgreeLayout;
 import com.rockwellcollins.atc.agree.analysis.AgreeRenaming;
-import com.rockwellcollins.atc.agree.analysis.lustre.visitors.RenamingVisitor;
-import com.rockwellcollins.atc.agree.analysis.translation.LustreAstBuilder;
 import com.rockwellcollins.atc.agree.analysis.ast.AgreeNode;
 import com.rockwellcollins.atc.agree.analysis.ast.AgreeProgram;
 import com.rockwellcollins.atc.agree.analysis.ast.AgreeVar;
+import com.rockwellcollins.atc.agree.analysis.lustre.visitors.RenamingVisitor;
+import com.rockwellcollins.atc.agree.analysis.translation.LustreAstBuilder;
 
 import edu.uah.rsesc.aadlsimulator.agree.SimulationProgram;
 import edu.uah.rsesc.aadlsimulator.agree.SimulationProgramBuilder;
 import edu.uah.rsesc.aadlsimulator.agree.SimulationProgramType;
 import edu.uah.rsesc.aadlsimulator.agree.SimulationVariable;
 import edu.uah.rsesc.aadlsimulator.agree.sim.AGREESimulatorException;
+import jkind.lustre.Program;
+import jkind.lustre.VarDecl;
 
 public class AgreeProgramToSimulationProgram {
 	public static SimulationProgram transform(final AgreeProgram agreeProgram, final SimulationProgramType type) {
 		Objects.requireNonNull(agreeProgram, "agreeProgram must not be null");
-		
+
 		// Build a Component Instance to AgreeNode map
 		final Program lustreProgram = LustreAstBuilder.getAssumeGuaranteeLustreProgram(agreeProgram);
-		final AgreeRenaming agreeRenaming = new AgreeRenaming(); 
+		final AgreeRenaming agreeRenaming = new AgreeRenaming();
 		final AgreeLayout layout = new AgreeLayout();
-		RenamingVisitor.addRenamings(lustreProgram, agreeRenaming, layout);
-		
+		RenamingVisitor.addRenamings(lustreProgram, agreeRenaming, agreeProgram.topNode.compInst, layout);
+
 		SimulationProgram program;
 		try {
 			final SimulationProgramBuilder builder = new SimulationProgramBuilder(type, agreeProgram.topNode.compInst, lustreProgram, agreeRenaming);
-			populateMetadata(builder, agreeProgram, lustreProgram, agreeRenaming, agreeRenaming.getRefMap());		
-			program = builder.build();			
+			populateMetadata(builder, agreeProgram, lustreProgram, agreeRenaming, agreeRenaming.getRefMap());
+			program = builder.build();
 		} catch(final Exception ex) {
 			throw new AGREESimulatorException(lustreProgram, ex);
 		}
-		
+
 		try {
 			program = CreateLocalVariablesForPropertyExpressions.transform(program);
 			program = RemovePropertySatisficationRequirements.transform(program);
@@ -78,16 +77,16 @@ public class AgreeProgramToSimulationProgram {
 
 		return program;
 	}
-	
+
 	private static void populateMetadata(final SimulationProgramBuilder builder, final AgreeProgram agreeProgram, final Program lustreProgram, final AgreeRenaming agreeRenaming, final Map<String, EObject> refMap) {
 		// For each input in the Lustre, determine which component instance it belongs to and create a simulation variable for it.
 		// Exclude inputs that are used internally by AGREE.
-		for(final VarDecl vd : lustreProgram.getMainNode().inputs) {		
+		for(final VarDecl vd : lustreProgram.getMainNode().inputs) {
 			if(vd instanceof AgreeVar) {
 				final AgreeVar agreeVar = (AgreeVar)vd;
 				if(agreeVar.compInst != null) {
 					final FeatureInstance featureInstance = agreeVar.featInst;
-					
+
 					// Use the name as provided by the instance object path unless it is not available
 					final String variableName;
 					if(featureInstance != null) {
@@ -95,17 +94,17 @@ public class AgreeProgramToSimulationProgram {
 					} else {
 						final String[] idSegs = vd.id.split("__");
 						variableName = idSegs[idSegs.length-1];
-					}						
+					}
 
 					builder.addSimulationVariable(new SimulationVariable(agreeVar.compInst, variableName, vd.id, vd.type, featureInstance, agreeVar.reference));
 				}
 			}
 		}
-		
+
 		// Add mappings from component instances to agree nodes
 		builder.addMapping(agreeProgram.topNode.compInst, agreeProgram.topNode);
 		for(final AgreeNode n : agreeProgram.agreeNodes) {
 			builder.addMapping(n.compInst, n);
-		}		
+		}
 	}
 }

--- a/fm-workbench/tcg/com.rockwellcollins.atc.tcg/src/com/rockwellcollins/atc/tcg/views/TcgLinkerFactory.java
+++ b/fm-workbench/tcg/com.rockwellcollins.atc.tcg/src/com/rockwellcollins/atc/tcg/views/TcgLinkerFactory.java
@@ -2,22 +2,22 @@
 Copyright (c) 2016, Rockwell Collins.
 Developed with the sponsorship of Defense Advanced Research Projects Agency (DARPA).
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this data, 
-including any software or models in source or binary form, as well as any drawings, specifications, 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this data,
+including any software or models in source or binary form, as well as any drawings, specifications,
 and documentation (collectively "the Data"), to deal in the Data without restriction, including
-without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Data, and to permit persons to whom the Data is furnished to do so, 
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Data, and to permit persons to whom the Data is furnished to do so,
 subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or 
+The above copyright notice and this permission notice shall be included in all copies or
 substantial portions of the Data.
 
-THE DATA IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
-LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS, SPONSORS, DEVELOPERS, CONTRIBUTORS, OR COPYRIGHT HOLDERS BE LIABLE 
-FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
+THE DATA IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS, SPONSORS, DEVELOPERS, CONTRIBUTORS, OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE DATA OR THE USE OR OTHER DEALINGS IN THE DATA.
-*/
+ */
 
 package com.rockwellcollins.atc.tcg.views;
 
@@ -25,12 +25,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
-
-import jkind.api.results.AnalysisResult;
-import jkind.api.results.CompositeAnalysisResult;
-import jkind.api.results.JKindResult;
-import jkind.lustre.Node;
-import jkind.lustre.Program;
 
 import org.eclipse.emf.common.util.EList;
 import org.osate.aadl2.AnnexSubclause;
@@ -51,20 +45,26 @@ import com.rockwellcollins.atc.agree.analysis.AgreeLayout;
 import com.rockwellcollins.atc.agree.analysis.AgreeLogger;
 import com.rockwellcollins.atc.agree.analysis.AgreeRenaming;
 import com.rockwellcollins.atc.agree.analysis.AgreeUtils;
+import com.rockwellcollins.atc.agree.analysis.ast.AgreeASTBuilder;
+import com.rockwellcollins.atc.agree.analysis.ast.AgreeProgram;
 import com.rockwellcollins.atc.agree.analysis.lustre.visitors.RenamingVisitor;
 import com.rockwellcollins.atc.agree.analysis.translation.LustreAstBuilder;
 import com.rockwellcollins.atc.agree.analysis.views.AgreeResultsLinker;
-import com.rockwellcollins.atc.agree.analysis.ast.AgreeASTBuilder;
-import com.rockwellcollins.atc.agree.analysis.ast.AgreeProgram;
 import com.rockwellcollins.atc.tcg.obligations.ufc.TcgRenaming;
+
+import jkind.api.results.AnalysisResult;
+import jkind.api.results.CompositeAnalysisResult;
+import jkind.api.results.JKindResult;
+import jkind.lustre.Node;
+import jkind.lustre.Program;
 
 public class TcgLinkerFactory {
 
 	private SystemInstance si;
 	private boolean monolithicAnalysis;
-	private TestSuiteLinker linker = new TestSuiteLinker(); 
-	private AnalysisResult result; 
-    protected Queue<JKindResult> queue = new ArrayDeque<>();
+	private TestSuiteLinker linker = new TestSuiteLinker();
+	private AnalysisResult result;
+	protected Queue<JKindResult> queue = new ArrayDeque<>();
 
 	public SystemInstance getSysInstance(ComponentImplementation ci) {
 		try {
@@ -75,127 +75,127 @@ public class TcgLinkerFactory {
 		}
 	}
 
-	
+
 	public TcgLinkerFactory(ComponentImplementation ci, boolean monolithicAnalysis, boolean allLayers) {
 		this.si = getSysInstance(ci);
 		this.monolithicAnalysis = monolithicAnalysis;
 
 		// check for AGREE Annex
-		
-        ComponentType sysType = AgreeUtils.getInstanceType(si);
-        EList<AnnexSubclause> annexSubClauses = AnnexUtil.getAllAnnexSubclauses(sysType,
-                AgreePackage.eINSTANCE.getAgreeContractSubclause());
 
-        if (annexSubClauses.size() == 0) {
-            throw new AgreeException(
-                    "There is not an AGREE annex in the '" + sysType.getName() + "' system type.");
-        }
+		ComponentType sysType = AgreeUtils.getInstanceType(si);
+		EList<AnnexSubclause> annexSubClauses = AnnexUtil.getAllAnnexSubclauses(sysType,
+				AgreePackage.eINSTANCE.getAgreeContractSubclause());
 
-        CompositeAnalysisResult wrapper = new CompositeAnalysisResult("");
+		if (annexSubClauses.size() == 0) {
+			throw new AgreeException(
+					"There is not an AGREE annex in the '" + sysType.getName() + "' system type.");
+		}
 
-        if (allLayers) {
-            result = buildAnalysisResult(ci.getName(), si);
-            wrapper.addChild(result);
-            result = wrapper;
+		CompositeAnalysisResult wrapper = new CompositeAnalysisResult("");
+
+		if (allLayers) {
+			result = buildAnalysisResult(ci.getName(), si);
+			wrapper.addChild(result);
+			result = wrapper;
 		} else {
-            wrapVerificationResult(si, wrapper);
-            result = wrapper;
+			wrapVerificationResult(si, wrapper);
+			result = wrapper;
 		}
 	}
-	
+
 	public AnalysisResult getAnalysisResult() { return result; }
 	public AgreeResultsLinker getLinker() { return linker; }
 	public Queue<JKindResult> getWorkQueue() { return queue; }
-	
+
 	// Routines for actually building the verification results...
-	
-    private void wrapVerificationResult(ComponentInstance si, CompositeAnalysisResult wrapper) {
-        AgreeProgram agreeProgram = new AgreeASTBuilder().getAgreeProgram(si, monolithicAnalysis);
-        Program program;
-        program = LustreAstBuilder.getAssumeGuaranteeLustreProgram(agreeProgram);
-        wrapper.addChild(
-                createVerification("Contract Test Cases", si, program, agreeProgram));
-    }
 
-    protected AnalysisResult createVerification(String resultName, ComponentInstance compInst, Program lustreProgram, AgreeProgram agreeProgram) {
+	private void wrapVerificationResult(ComponentInstance si, CompositeAnalysisResult wrapper) {
+		AgreeProgram agreeProgram = new AgreeASTBuilder().getAgreeProgram(si, monolithicAnalysis);
+		Program program;
+		program = LustreAstBuilder.getAssumeGuaranteeLustreProgram(agreeProgram);
+		wrapper.addChild(
+				createVerification("Contract Test Cases", si, program, agreeProgram));
+	}
 
-		AgreeRenaming agreeRenaming = new AgreeRenaming(); 
+	protected AnalysisResult createVerification(String resultName, ComponentInstance compInst, Program lustreProgram, AgreeProgram agreeProgram) {
+
+		AgreeRenaming agreeRenaming = new AgreeRenaming();
 		AgreeLayout layout = new AgreeLayout();
-		RenamingVisitor.addRenamings(lustreProgram, agreeRenaming, layout);
+		RenamingVisitor.addRenamings(lustreProgram, agreeRenaming, compInst, layout);
 		TcgRenaming renaming = new TcgRenaming(agreeRenaming, agreeRenaming.getRefMap());
-        Node mainNode = lustreProgram.getMainNode();
-        if (mainNode == null) {
-            throw new AgreeException("Could not find main lustre node after translation");
-        }
+		Node mainNode = lustreProgram.getMainNode();
+		if (mainNode == null) {
+			throw new AgreeException("Could not find main lustre node after translation");
+		}
 
-        List<String> properties = new ArrayList<>();
-        
-        JKindResult result;
-        result = new JKindResult(resultName, properties, renaming);
-        queue.add(result);
+		List<String> properties = new ArrayList<>();
 
-        ComponentImplementation compImpl = AgreeUtils.getInstanceImplementation(compInst);
-        linker.setAgreeProgram(result, agreeProgram);
-        linker.setProgram(result, lustreProgram);
-        linker.setComponent(result, compImpl);
-        linker.setContract(result, getContract(compImpl));
-        linker.setLayout(result, layout);
-        // linker.setReferenceMap(result, renaming.getRefMap());
-        linker.setLog(result, AgreeLogger.getLog());
-        linker.setRenaming(result, renaming);
+		JKindResult result;
+		result = new JKindResult(resultName, properties, renaming);
+		queue.add(result);
 
-        // System.out.println(program);
-        return result;
+		ComponentImplementation compImpl = AgreeUtils.getInstanceImplementation(compInst);
+		linker.setAgreeProgram(result, agreeProgram);
+		linker.setProgram(result, lustreProgram);
+		linker.setComponent(result, compImpl);
+		linker.setContract(result, getContract(compImpl));
+		linker.setLayout(result, layout);
+		// linker.setReferenceMap(result, renaming.getRefMap());
+		linker.setLog(result, AgreeLogger.getLog());
+		linker.setRenaming(result, renaming);
 
-    }
+		// System.out.println(program);
+		return result;
 
-    private AgreeSubclause getContract(ComponentImplementation ci) {
-        ComponentType ct = ci.getOwnedRealization().getImplemented();
-        for (AnnexSubclause annex : ct.getOwnedAnnexSubclauses()) {
-            if (annex instanceof AgreeSubclause) {
-                return (AgreeSubclause) annex;
-            }
-        }
-        return null;
-    }
+	}
 
-    
-    private AnalysisResult buildAnalysisResult(String name, ComponentInstance ci) {
-        CompositeAnalysisResult result = new CompositeAnalysisResult("Test case generation for " + name);
+	private AgreeSubclause getContract(ComponentImplementation ci) {
+		ComponentType ct = ci.getOwnedRealization().getImplemented();
+		for (AnnexSubclause annex : ct.getOwnedAnnexSubclauses()) {
+			if (annex instanceof AgreeSubclause) {
+				return (AgreeSubclause) annex;
+			}
+		}
+		return null;
+	}
 
-        if (containsAGREEAnnex(ci)) {
-            wrapVerificationResult(ci, result);
-            ComponentImplementation compImpl = AgreeUtils.getInstanceImplementation(ci);
-            for (ComponentInstance subInst : ci.getComponentInstances()) {
-                if (AgreeUtils.getInstanceImplementation(subInst) != null) {
-                    AnalysisResult buildAnalysisResult = buildAnalysisResult(subInst.getName(), subInst);
-                    if (buildAnalysisResult != null) {
-                        result.addChild(buildAnalysisResult);
-                    }
-                }
-            }
 
-            if (result.getChildren().size() != 0) {
-                linker.setComponent(result, compImpl);
-                return result;
-            }
-        }
-        return null;
-    }
+	private AnalysisResult buildAnalysisResult(String name, ComponentInstance ci) {
+		CompositeAnalysisResult result = new CompositeAnalysisResult("Test case generation for " + name);
 
-    private boolean containsAGREEAnnex(ComponentInstance ci) {
-        ComponentClassifier compClass = ci.getComponentClassifier();
-        if (compClass instanceof ComponentImplementation) {
-            compClass = ((ComponentImplementation) compClass).getType();
-        }
-        for (AnnexSubclause annex : AnnexUtil.getAllAnnexSubclauses(compClass,
-                AgreePackage.eINSTANCE.getAgreeContractSubclause())) {
-            if (annex instanceof AgreeContractSubclause) {
-                return true;
-            }
-        }
-        return false;
-    }
+		if (containsAGREEAnnex(ci)) {
+			wrapVerificationResult(ci, result);
+			ComponentImplementation compImpl = AgreeUtils.getInstanceImplementation(ci);
+			for (ComponentInstance subInst : ci.getComponentInstances()) {
+				if (AgreeUtils.getInstanceImplementation(subInst) != null) {
+					AnalysisResult buildAnalysisResult = buildAnalysisResult(subInst.getName(), subInst);
+					if (buildAnalysisResult != null) {
+						result.addChild(buildAnalysisResult);
+					}
+				}
+			}
+
+			if (result.getChildren().size() != 0) {
+				linker.setComponent(result, compImpl);
+				return result;
+			}
+		}
+		return null;
+	}
+
+	private boolean containsAGREEAnnex(ComponentInstance ci) {
+		ComponentClassifier compClass = ci.getComponentClassifier();
+		if (compClass instanceof ComponentImplementation) {
+			compClass = ((ComponentImplementation) compClass).getType();
+		}
+		for (AnnexSubclause annex : AnnexUtil.getAllAnnexSubclauses(compClass,
+				AgreePackage.eINSTANCE.getAgreeContractSubclause())) {
+			if (annex instanceof AgreeContractSubclause) {
+				return true;
+			}
+		}
+		return false;
+	}
 
 
 }


### PR DESCRIPTION
Fix as per description in [Issue 75](https://github.com/smaccm/smaccm/issues/75).

The problem was incorrect signal categories and reference maps due to incorrect computation of the relative instance path to the variable declaration.