### PR TITLE
Add ability for AGREE to access AADL property constants

### DIFF
--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/AgreeUtils.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/AgreeUtils.java
@@ -23,6 +23,7 @@ import org.osate.aadl2.ComponentImplementation;
 import org.osate.aadl2.ComponentType;
 import org.osate.aadl2.NamedElement;
 import org.osate.aadl2.Property;
+import org.osate.aadl2.PropertyConstant;
 import org.osate.aadl2.PropertyExpression;
 import org.osate.aadl2.Subcomponent;
 import org.osate.aadl2.instance.ComponentInstance;
@@ -73,6 +74,16 @@ public class AgreeUtils {
 			// property is associated
 			expr = PropertyUtils.getSimplePropertyValue(comp, prop);
 			return expr;
+		} catch (PropertyDoesNotApplyToHolderException propException) {
+			return null;
+		} catch (PropertyNotPresentException propNotPresentException) {
+			return null;
+		}
+	}
+
+	static public PropertyExpression getPropExpression(PropertyConstant prop) {
+		try {
+			return prop.getConstantValue();
 		} catch (PropertyDoesNotApplyToHolderException propException) {
 			return null;
 		} catch (PropertyNotPresentException propNotPresentException) {

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree/src/com/rockwellcollins/atc/agree/validation/AgreeJavaValidator.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree/src/com/rockwellcollins/atc/agree/validation/AgreeJavaValidator.java
@@ -57,6 +57,7 @@ import org.osate.aadl2.Feature;
 //import org.osate.aadl2.ListValue;
 import org.osate.aadl2.NamedElement;
 import org.osate.aadl2.Property;
+import org.osate.aadl2.PropertyConstant;
 //import org.osate.aadl2.PropertyExpression;
 import org.osate.aadl2.PropertyType;
 import org.osate.aadl2.Subcomponent;
@@ -1886,8 +1887,8 @@ public class AgreeJavaValidator extends AbstractAgreeJavaValidator {
 			error(getPropExpr.getComponent(), "Expected type component, but found type " + compType);
 		}
 
-		if (!(prop instanceof Property)) {
-			error(getPropExpr.getProp(), "Expected AADL property");
+		if (!(prop instanceof Property || prop instanceof PropertyConstant)) {
+			error(getPropExpr.getProp(), "Expected AADL property or property constant");
 		}
 	}
 
@@ -2334,9 +2335,13 @@ public class AgreeJavaValidator extends AbstractAgreeJavaValidator {
 	}
 
 	protected AgreeType getAgreeType(NamedElement namedEl) {
-		if (namedEl instanceof Property) {
-			Property propVal = (Property) namedEl;
-			PropertyType propType = propVal.getPropertyType();
+		if ((namedEl instanceof Property) || namedEl instanceof PropertyConstant) {
+			PropertyType propType;
+			if (namedEl instanceof Property) {
+				propType = ((Property) namedEl).getPropertyType();
+			} else {
+				propType = ((PropertyConstant) namedEl).getPropertyType();
+			}
 
 			if (propType instanceof AadlBoolean) {
 				return BOOL;


### PR DESCRIPTION
This pull request is intended to resolve [Issue 77](https://github.com/smaccm/smaccm/issues/77).

Modify the Validator and AGREE AST Builder as per comments in the issue description.