### PR TITLE
Allow executing AGREE analysis and TCG from graphical editor.

### DIFF
--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/META-INF/MANIFEST.MF
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/META-INF/MANIFEST.MF
@@ -16,7 +16,9 @@ Require-Bundle: org.eclipse.ui,
  org.osate.xtext.aadl2.properties;bundle-version="1.0.0",
  com.rockwellcollins.atc.agree;bundle-version="1.0.0",
  com.rockwellcollins.atc.agree.ui;bundle-version="1.0.0",
- com.rockwellcollins.atc.z3;resolution:=optional
+ com.rockwellcollins.atc.z3;resolution:=optional,
+ org.osate.ge,
+ org.eclipse.emf.ecore
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/plugin.xml
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/plugin.xml
@@ -309,6 +309,22 @@
 	         </with>
           <reference definitionId="org.osate.xtext.aadl2.Aadl2.Editor.opened">
           </reference>
+ 			<with
+                variable="selection">
+               <adapt
+                     type="org.osate.ge.BusinessObjectSelection">
+	               <count
+	                     value="1">
+	               </count>
+	               <iterate
+	                     ifEmpty="false"
+	                     operator="or">
+	                  <instanceof
+	                        value="org.eclipse.emf.ecore.EObject">
+	                  </instanceof>
+	               </iterate>
+               </adapt>
+          </with>
          </or>
       </definition>
    </extension>

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/handlers/ModifyingAadlHandler.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/handlers/ModifyingAadlHandler.java
@@ -1,10 +1,17 @@
 package com.rockwellcollins.atc.agree.analysis.handlers;
 
+import java.io.IOException;
+
 import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.xtext.resource.SaveOptions;
 import org.eclipse.xtext.ui.editor.XtextEditor;
+import org.osate.aadl2.modelsupport.resources.OsateResourceUtil;
 
 public abstract class ModifyingAadlHandler extends AadlHandler {
 	@Override
@@ -15,7 +22,25 @@ public abstract class ModifyingAadlHandler extends AadlHandler {
 				// modification may update text editors so we need to run in the SWT thread
 				IStatus[] status = new IStatus[1];
 				getWindow().getShell().getDisplay().syncExec(() -> {
-					status[0] = xtextEditor.getDocument().modify(getUnitOfWork(uri, monitor));
+					if (xtextEditor == null) {
+						final ResourceSet rs = OsateResourceUtil.getResourceSet();
+						status[0] = getWorker(uri, monitor).apply(rs);
+
+						// Save the model
+						final EObject eobj = rs.getEObject(uri, true);
+						if (eobj != null) {
+							final Resource resource = eobj.eResource();
+							if (resource != null) {
+								try {
+									resource.save(SaveOptions.newBuilder().format().getOptions().toOptionsMap());
+								} catch (final IOException e) {
+									throw new RuntimeException(e);
+								}
+							}
+						}
+					} else {
+						status[0] = xtextEditor.getDocument().modify(getUnitOfWork(uri, monitor));
+					}
 				});
 				return status[0];
 			};

--- a/fm-workbench/tcg/com.rockwellcollins.atc.tcg/META-INF/MANIFEST.MF
+++ b/fm-workbench/tcg/com.rockwellcollins.atc.tcg/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.ui,
  org.osate.annexsupport;bundle-version="1.0.0",
  com.rockwellcollins.atc.agree;bundle-version="2.0.0",
  com.rockwellcollins.atc.agree.analysis;bundle-version="2.0.0",
- edu.uah.rsesc.aadlsimulator.agree;bundle-version="0.1.0";resolution:=optional
+ edu.uah.rsesc.aadlsimulator.agree;bundle-version="0.1.0";resolution:=optional,
+ org.osate.ge
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Rockwell Collins

--- a/fm-workbench/tcg/com.rockwellcollins.atc.tcg/src/com/rockwellcollins/atc/tcg/handlers/AadlHandler.java
+++ b/fm-workbench/tcg/com.rockwellcollins.atc.tcg/src/com/rockwellcollins/atc/tcg/handlers/AadlHandler.java
@@ -2,47 +2,54 @@
 Copyright (c) 2016, Rockwell Collins.
 Developed with the sponsorship of Defense Advanced Research Projects Agency (DARPA).
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this data, 
-including any software or models in source or binary form, as well as any drawings, specifications, 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this data,
+including any software or models in source or binary form, as well as any drawings, specifications,
 and documentation (collectively "the Data"), to deal in the Data without restriction, including
-without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Data, and to permit persons to whom the Data is furnished to do so, 
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Data, and to permit persons to whom the Data is furnished to do so,
 subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or 
+The above copyright notice and this permission notice shall be included in all copies or
 substantial portions of the Data.
 
-THE DATA IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
-LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS, SPONSORS, DEVELOPERS, CONTRIBUTORS, OR COPYRIGHT HOLDERS BE LIABLE 
-FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
+THE DATA IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS, SPONSORS, DEVELOPERS, CONTRIBUTORS, OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE DATA OR THE USE OR OTHER DEALINGS IN THE DATA.
 */
 
 package com.rockwellcollins.atc.tcg.handlers;
 
+import java.util.function.Function;
+
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.handlers.HandlerUtil;
-import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.resource.EObjectAtOffsetHelper;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.outline.impl.EObjectNode;
 import org.eclipse.xtext.ui.editor.utils.EditorUtils;
-import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 import org.osate.aadl2.Element;
+import org.osate.aadl2.modelsupport.resources.OsateResourceUtil;
+import org.osate.ge.BusinessObjectSelection;
 
 public abstract class AadlHandler extends AbstractHandler {
     protected static final String TERMINATE_ID = "tcg.commands.terminate";
@@ -54,11 +61,10 @@ public abstract class AadlHandler extends AbstractHandler {
 
 	@Override
 	public Object execute(ExecutionEvent event) {
-		EObjectNode node = getEObjectNode(HandlerUtil.getCurrentSelection(event));
-		if (node == null) {
+		final URI uri = getSelectionURI(HandlerUtil.getCurrentSelection(event));
+		if (uri == null) {
 			return null;
 		}
-		final URI uri = node.getEObjectURI();
 
 		window = HandlerUtil.getActiveWorkbenchWindow(event);
 		if (window == null) {
@@ -69,29 +75,30 @@ public abstract class AadlHandler extends AbstractHandler {
 	}
 
 	public Object executeURI(final URI uri) {
-		final XtextEditor xtextEditor = EditorUtils.getActiveXtextEditor();
-		if (xtextEditor == null) {
-			return null;
-		}
-
 		if (!saveChanges(window.getActivePage().getDirtyEditors())) {
 			return null;
 		}
 
+		final XtextEditor xtextEditor = EditorUtils.getActiveXtextEditor();
 		WorkspaceJob job = new WorkspaceJob(getJobName()) {
 			@Override
 			public IStatus runInWorkspace(final IProgressMonitor monitor) {
-				return xtextEditor.getDocument().readOnly(new IUnitOfWork<IStatus, XtextResource>() {
-					@Override
-					public IStatus exec(XtextResource resource) throws Exception {
-						EObject eobj = resource.getResourceSet().getEObject(uri, true);
-						if (eobj instanceof Element) {
-							return runJob((Element) eobj, monitor);
-						} else {
-							return Status.CANCEL_STATUS;
-						}
+				final Function<ResourceSet, IStatus> worker = resourceSet -> {
+					EObject eobj = resourceSet.getEObject(uri, true);
+					if (eobj instanceof Element) {
+						return runJob((Element) eobj, monitor);
+					} else {
+						return Status.CANCEL_STATUS;
 					}
-				});
+				};
+
+				if (xtextEditor == null) {
+					return worker.apply(OsateResourceUtil.getResourceSet());
+				} else {
+					return xtextEditor.getDocument().readOnly(resource -> {
+						return worker.apply(resource.getResourceSet());
+					});
+				}
 			}
 		};
 
@@ -116,12 +123,28 @@ public abstract class AadlHandler extends AbstractHandler {
 		}
 	}
 
-	private EObjectNode getEObjectNode(ISelection currentSelection) {
+	private URI getSelectionURI(ISelection currentSelection) {
 		if (currentSelection instanceof IStructuredSelection) {
 			IStructuredSelection iss = (IStructuredSelection) currentSelection;
-			if (iss.size() == 1) {
-				return (EObjectNode) iss.getFirstElement();
+			if (iss.size() == 1 && iss.getFirstElement() instanceof EObjectNode) {
+				EObjectNode node = (EObjectNode) iss.getFirstElement();
+				return node.getEObjectURI();
+			} else {
+				final BusinessObjectSelection bos = Adapters.adapt(currentSelection, BusinessObjectSelection.class);
+				if (bos != null) {
+					if (bos.boStream(Element.class).count() == 1) {
+						return bos.boStream(EObject.class).findFirst().map(e -> EcoreUtil.getURI(e)).orElse(null);
+					}
+				}
 			}
+		} else if (currentSelection instanceof TextSelection) {
+			// Selection may be stale, get latest from editor
+			XtextEditor xtextEditor = EditorUtils.getActiveXtextEditor();
+			TextSelection ts = (TextSelection) xtextEditor.getSelectionProvider().getSelection();
+			return xtextEditor.getDocument().readOnly(resource -> {
+				EObject e = new EObjectAtOffsetHelper().resolveContainedElementAt(resource, ts.getOffset());
+				return EcoreUtil.getURI(e);
+			});
 		}
 		return null;
 	}


### PR DESCRIPTION
Updates handlers for AGREE and TCG to enable top-level AGREE menu items
when working in the graphical editor.

This requires the develop version of the OSATE graphical editor. If an older version is used, no ill effects are expected but the menu items will not be enabled.