### PR TITLE
Support AADL data subranges in AGREE

### DIFF
--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/ast/AgreeASTBuilder.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/ast/AgreeASTBuilder.java
@@ -23,6 +23,8 @@ import org.osate.aadl2.ConnectedElement;
 import org.osate.aadl2.Connection;
 import org.osate.aadl2.ConnectionEnd;
 import org.osate.aadl2.Context;
+import org.osate.aadl2.DataClassifier;
+import org.osate.aadl2.DataImplementation;
 import org.osate.aadl2.DataPort;
 import org.osate.aadl2.DataSubcomponent;
 import org.osate.aadl2.DataSubcomponentType;
@@ -639,22 +641,24 @@ public class AgreeASTBuilder extends AgreeSwitch<Expr> {
 			// we do not reason about this type
 			return;
 		}
-		DataType dt;
-//		NamedType agreeType = getNamedType(AgreeTypeUtils.getTypeName(type, typeMap, globalTypes));
 
 		AgreeVar agreeVar = new AgreeVar(name, type, feature.getFeature(), feature.getComponentInstance(), feature);
 
 		switch (feature.getDirection()) {
 		case IN:
 			inputs.add(agreeVar);
-			if (dataClass instanceof DataType) {
-				assumptions.addAll(getDataTypeRangeConstraint(feature.getName(), (DataType) dataClass, dataFeature));
+			if (dataClass instanceof DataClassifier) {
+				assumptions
+				.addAll(getDataClassifierRangeConstraint(feature.getName(), (DataClassifier) dataClass,
+						dataFeature));
 			}
 			break;
 		case OUT:
 			outputs.add(agreeVar);
-			if (dataClass instanceof DataType) {
-				guarantees.addAll(getDataTypeRangeConstraint(feature.getName(), (DataType) dataClass, dataFeature));
+			if (dataClass instanceof DataClassifier) {
+				guarantees
+				.addAll(getDataClassifierRangeConstraint(feature.getName(), (DataClassifier) dataClass,
+						dataFeature));
 			}
 			break;
 		default:
@@ -1100,99 +1104,62 @@ public class AgreeASTBuilder extends AgreeSwitch<Expr> {
 		return result;
 	}
 
-//	private List<AgreeStatement> getFeatureRangeConstraint(DataSubcomponentType dataSubcomponentType) {
-//		List<AgreeStatement> constraints = new ArrayList<>();
-//
-//		// TODO: Need to make this recursively descend into the subcomponents
-//		if (hasIntegerRangeProperty((ComponentClassifier) recordTypeName)) {
-//			for (PropertyAssociation pa : getIntegerRangePropertyAssociations(dataSubcomponentType)) {
-//				for (ModalPropertyValue pv : pa.getOwnedValues()) {
-//					PropertyExpression propExpr = pv.getOwnedValue();
-//					if (propExpr instanceof RangeValue) {
-//						RangeValue rangeValue = (RangeValue) propExpr;
-//						double min = rangeValue.getMinimumValue().getScaledValue();
-//						double max = rangeValue.getMaximumValue().getScaledValue();
-//						IdExpr id = new IdExpr(name);
-//						Expr lowVal = new IntExpr(BigDecimal.valueOf(min).toBigInteger());
-//						Expr highVal = new IntExpr(BigDecimal.valueOf(max).toBigInteger());
-//						Expr lowBound = new BinaryExpr(lowVal, BinaryOp.LESSEQUAL, id);
-//						Expr highBound = new BinaryExpr(id, BinaryOp.LESSEQUAL, highVal);
-//						Expr bound = new BinaryExpr(lowBound, BinaryOp.AND, highBound);
-//						// must have reference to reference so we don't throw
-//						// them away later
-//						constraints.add(new AgreeStatement("Type predicate on '" + name + "'", bound, reference));
-//					}
-//				}
-//			}
-//		} else if (hasRealRangeProperty(dataSubcomponentType)) {
-//			for (PropertyAssociation pa : getRealRangePropertyAssociations((ComponentClassifier) recordTypeName)) {
-//				for (ModalPropertyValue pv : pa.getOwnedValues()) {
-//					PropertyExpression propExpr = pv.getOwnedValue();
-//					if (propExpr instanceof RangeValue) {
-//						RangeValue rangeValue = (RangeValue) propExpr;
-//						double min = rangeValue.getMinimumValue().getScaledValue();
-//						double max = rangeValue.getMaximumValue().getScaledValue();
-//						IdExpr id = new IdExpr(name);
-//						Expr lowVal = new RealExpr(BigDecimal.valueOf(min));
-//						Expr highVal = new RealExpr(BigDecimal.valueOf(max));
-//						Expr lowBound = new BinaryExpr(lowVal, BinaryOp.LESSEQUAL, id);
-//						Expr highBound = new BinaryExpr(id, BinaryOp.LESSEQUAL, highVal);
-//						Expr bound = new BinaryExpr(lowBound, BinaryOp.AND, highBound);
-//						// must have reference to reference so we don't throw
-//						// them away later
-//						constraints.add(new AgreeStatement("Type predicate on '" + name + "'", bound, reference));
-//					}
-//				}
-//			}
-//		}
-//
-//		return constraints;
-//	}
-
-	private List<AgreeStatement> getDataTypeRangeConstraint(String name, DataType dataType, EObject reference) {
+	private List<AgreeStatement> getDataClassifierRangeConstraint(String name, DataClassifier dataClassifier,
+			EObject reference) {
 		List<AgreeStatement> constraints = new ArrayList<>();
-		// TODO: Need to make this recursively descend into the record subcomponents
-		if (hasIntegerRangeProperty(dataType)) {
-			for (PropertyAssociation pa : getIntegerRangePropertyAssociations(dataType)) {
-				for (ModalPropertyValue pv : pa.getOwnedValues()) {
-					PropertyExpression propExpr = pv.getOwnedValue();
-					if (propExpr instanceof RangeValue) {
-						RangeValue rangeValue = (RangeValue) propExpr;
-						double min = rangeValue.getMinimumValue().getScaledValue();
-						double max = rangeValue.getMaximumValue().getScaledValue();
-						IdExpr id = new IdExpr(name);
-						Expr lowVal = new IntExpr(BigDecimal.valueOf(min).toBigInteger());
-						Expr highVal = new IntExpr(BigDecimal.valueOf(max).toBigInteger());
-						Expr lowBound = new BinaryExpr(lowVal, BinaryOp.LESSEQUAL, id);
-						Expr highBound = new BinaryExpr(id, BinaryOp.LESSEQUAL, highVal);
-						Expr bound = new BinaryExpr(lowBound, BinaryOp.AND, highBound);
-						// must have reference to reference so we don't throw
-						// them away later
-						constraints.add(new AgreeStatement("Type predicate on '" + name + "'", bound, reference));
+
+		if (dataClassifier instanceof DataType) {
+			if (hasIntegerRangeProperty(dataClassifier)) {
+				for (PropertyAssociation pa : getIntegerRangePropertyAssociations(dataClassifier)) {
+					for (ModalPropertyValue pv : pa.getOwnedValues()) {
+						PropertyExpression propExpr = pv.getOwnedValue();
+						if (propExpr instanceof RangeValue) {
+							RangeValue rangeValue = (RangeValue) propExpr;
+							double min = rangeValue.getMinimumValue().getScaledValue();
+							double max = rangeValue.getMaximumValue().getScaledValue();
+							IdExpr id = new IdExpr(name);
+							Expr lowVal = new IntExpr(BigDecimal.valueOf(min).toBigInteger());
+							Expr highVal = new IntExpr(BigDecimal.valueOf(max).toBigInteger());
+							Expr lowBound = new BinaryExpr(lowVal, BinaryOp.LESSEQUAL, id);
+							Expr highBound = new BinaryExpr(id, BinaryOp.LESSEQUAL, highVal);
+							Expr bound = new BinaryExpr(lowBound, BinaryOp.AND, highBound);
+							// must have reference to reference so we don't throw
+							// them away later
+							constraints.add(new AgreeStatement("Type predicate on '" + name + "'", bound, reference));
+						}
+					}
+				}
+			} else if (hasRealRangeProperty(dataClassifier)) {
+				for (PropertyAssociation pa : getRealRangePropertyAssociations(dataClassifier)) {
+					for (ModalPropertyValue pv : pa.getOwnedValues()) {
+						PropertyExpression propExpr = pv.getOwnedValue();
+						if (propExpr instanceof RangeValue) {
+							RangeValue rangeValue = (RangeValue) propExpr;
+							double min = rangeValue.getMinimumValue().getScaledValue();
+							double max = rangeValue.getMaximumValue().getScaledValue();
+							IdExpr id = new IdExpr(name);
+							Expr lowVal = new RealExpr(BigDecimal.valueOf(min));
+							Expr highVal = new RealExpr(BigDecimal.valueOf(max));
+							Expr lowBound = new BinaryExpr(lowVal, BinaryOp.LESSEQUAL, id);
+							Expr highBound = new BinaryExpr(id, BinaryOp.LESSEQUAL, highVal);
+							Expr bound = new BinaryExpr(lowBound, BinaryOp.AND, highBound);
+							// must have reference to reference so we don't throw
+							// them away later
+							constraints.add(new AgreeStatement("Type predicate on '" + name + "'", bound, reference));
+						}
 					}
 				}
 			}
-		} else if (hasRealRangeProperty(dataType)) {
-			for (PropertyAssociation pa : getRealRangePropertyAssociations(dataType)) {
-				for (ModalPropertyValue pv : pa.getOwnedValues()) {
-					PropertyExpression propExpr = pv.getOwnedValue();
-					if (propExpr instanceof RangeValue) {
-						RangeValue rangeValue = (RangeValue) propExpr;
-						double min = rangeValue.getMinimumValue().getScaledValue();
-						double max = rangeValue.getMaximumValue().getScaledValue();
-						IdExpr id = new IdExpr(name);
-						Expr lowVal = new RealExpr(BigDecimal.valueOf(min));
-						Expr highVal = new RealExpr(BigDecimal.valueOf(max));
-						Expr lowBound = new BinaryExpr(lowVal, BinaryOp.LESSEQUAL, id);
-						Expr highBound = new BinaryExpr(id, BinaryOp.LESSEQUAL, highVal);
-						Expr bound = new BinaryExpr(lowBound, BinaryOp.AND, highBound);
-						// must have reference to reference so we don't throw
-						// them away later
-						constraints.add(new AgreeStatement("Type predicate on '" + name + "'", bound, reference));
-					}
-				}
-			}
+
+		} else if (dataClassifier instanceof DataImplementation) {
+			constraints.addAll(((DataImplementation) dataClassifier).getAllSubcomponents().stream()
+					.filter(sub -> sub.getSubcomponentType() instanceof DataClassifier)
+					.map(sub -> getDataClassifierRangeConstraint(name + "." + sub.getName(),
+							(DataClassifier) sub.getSubcomponentType(),
+							reference))
+					.flatMap(List::stream).collect(Collectors.toList()));
 		}
+
 		return constraints;
 	}
 
@@ -1237,8 +1204,8 @@ public class AgreeASTBuilder extends AgreeSwitch<Expr> {
 		} else if (type instanceof RecordType) {
 			RecordType recType = (RecordType) type;
 			NamedElement recordTypeName = AgreeUtils.getFinalNestId(recType.getRecord());
-			if (recordTypeName instanceof DataType) {
-				constraints.addAll(getDataTypeRangeConstraint(name, (DataType) recordTypeName, reference));
+			if (recordTypeName instanceof DataClassifier) {
+				constraints.addAll(getDataClassifierRangeConstraint(name, (DataClassifier) recordTypeName, reference));
 			}
 		}
 		return constraints;

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/lustre/visitors/RenamingVisitor.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/lustre/visitors/RenamingVisitor.java
@@ -1,5 +1,7 @@
 package com.rockwellcollins.atc.agree.analysis.lustre.visitors;
 
+import java.util.stream.Collectors;
+
 import org.eclipse.emf.ecore.EObject;
 import org.osate.aadl2.ComponentImplementation;
 import org.osate.aadl2.ComponentType;
@@ -12,6 +14,7 @@ import org.osate.aadl2.instance.ComponentInstance;
 import com.rockwellcollins.atc.agree.agree.Arg;
 import com.rockwellcollins.atc.agree.agree.AssertStatement;
 import com.rockwellcollins.atc.agree.agree.AssumeStatement;
+import com.rockwellcollins.atc.agree.agree.EqStatement;
 import com.rockwellcollins.atc.agree.agree.GuaranteeStatement;
 import com.rockwellcollins.atc.agree.agree.LemmaStatement;
 import com.rockwellcollins.atc.agree.agree.PropertyStatement;
@@ -145,6 +148,10 @@ public class RenamingVisitor extends AstIterVisitor {
 			throw new AgreeException("We really didn't expect to see an assert statement here");
 		} else if (reference instanceof Arg) {
 			return prefix + seperator + ((Arg) reference).getName() + suffix;
+		} else if (reference instanceof EqStatement) {
+			return prefix + "eq: " + String.join(", ",
+					((EqStatement) reference).getLhs().stream().map(lhs -> lhs.getName()).collect(Collectors.toList()))
+			+ suffix;
 		} else if (reference instanceof DataPort) {
 			return prefix + seperator + ((DataPort) reference).getName() + suffix;
 		} else if (reference instanceof EventDataPort) {

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/lustre/visitors/RenamingVisitor.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/lustre/visitors/RenamingVisitor.java
@@ -16,6 +16,7 @@ import com.rockwellcollins.atc.agree.agree.AssertStatement;
 import com.rockwellcollins.atc.agree.agree.AssumeStatement;
 import com.rockwellcollins.atc.agree.agree.EqStatement;
 import com.rockwellcollins.atc.agree.agree.GuaranteeStatement;
+import com.rockwellcollins.atc.agree.agree.InputStatement;
 import com.rockwellcollins.atc.agree.agree.LemmaStatement;
 import com.rockwellcollins.atc.agree.agree.NestedDotID;
 import com.rockwellcollins.atc.agree.agree.PrimType;
@@ -183,6 +184,9 @@ public class RenamingVisitor extends AstIterVisitor {
 			return prefix + "eq " + String.join(", ",
 					((EqStatement) reference).getLhs().stream().map(lhs -> argToString(lhs))
 					.collect(Collectors.toList()));
+		} else if (reference instanceof InputStatement) {
+			return prefix + "agree_input " + String.join(", ", ((InputStatement) reference).getLhs().stream()
+					.map(lhs -> argToString(lhs)).collect(Collectors.toList()));
 		} else if (reference instanceof DataPort) {
 			return prefix + seperator + ((DataPort) reference).getName() + suffix;
 		} else if (reference instanceof EventDataPort) {

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree/src/com/rockwellcollins/atc/agree/validation/AgreeJavaValidator.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree/src/com/rockwellcollins/atc/agree/validation/AgreeJavaValidator.java
@@ -356,8 +356,8 @@ public class AgreeJavaValidator extends AbstractAgreeJavaValidator {
 
 				// this is a ranged argument. It can only show up in an equation statement
 				EObject container = arg.eContainer();
-				if (!(container instanceof EqStatement)) {
-					error(arg, "Ranged arguments can only appear in equation statements");
+				if (!(container instanceof EqStatement || container instanceof InputStatement)) {
+					error(arg, "Ranged arguments can only appear in equation statements or agree_input statements");
 				}
 
 				boolean rangeLowDot = rangeLow.contains(".");

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree/src/com/rockwellcollins/atc/agree/validation/AgreeJavaValidator.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree/src/com/rockwellcollins/atc/agree/validation/AgreeJavaValidator.java
@@ -323,6 +323,10 @@ public class AgreeJavaValidator extends AbstractAgreeJavaValidator {
 			error(dotId, "The Id on the left hand side of an assignment statement " + "must not contain a \".\"");
 		}
 
+		if (namedEl.eContainer() instanceof InputStatement) {
+			error(dotId, "Assignment to agree_input variables is illegal.");
+		}
+
 		AgreeType lhsType = getAgreeType(namedEl);
 		AgreeType rhsType = getAgreeType(expr);
 


### PR DESCRIPTION
This pull request is intended to resolve [Issue76](https://github.com/smaccm/smaccm/issues/76).

Implemented generation of type predicates as assumptions on inputs and guarantees (obligations) on outputs.  Also handles `agree_input` statements and `eq` statements of AADL type with data range.