### PR TITLE
Fix comparison of NamedElement instances

### DIFF
--- a/fm-workbench/releng/2.3.3.md
+++ b/fm-workbench/releng/2.3.3.md
@@ -1,0 +1,85 @@
+Resolute
+--------
+
+### Enhancements:
+
+-   Resolute collection semantics
+    ([\#91](https://github.com/smaccm/smaccm/issues/91))
+
+### Issues Addressed:
+
+-   Restore non-short-circuit behavior for logical oerator evaluation in
+    claims ([\#122](https://github.com/smaccm/smaccm/issues/122))
+-   Fix exception computing return type of list/set function
+    ([\#121](https://github.com/smaccm/smaccm/issues/121))
+-   Fix stack overflow in Resolute validation
+    ([\#117](https://github.com/smaccm/smaccm/issues/117))
+-   Fix connected function to correctly handle connection instances
+    ([\#100](https://github.com/smaccm/smaccm/issues/100))
+-   Remove remnants of D-Case export
+    ([\#93](https://github.com/smaccm/smaccm/issues/93))
+
+### Known Issues:
+
+-   Mixing claim functions and compute functions omits display of some
+    subclaims ([\#127](https://github.com/smaccm/smaccm/issues/127))
+-   No way to access AGREE as external analysis from Resolute
+    ([\#90](https://github.com/smaccm/smaccm/issues/90))
+
+AGREE
+-----
+
+### Enhancements:
+
+-   Analysis of AGREE models with unspecified AADL properties
+    ([\#98](https://github.com/smaccm/smaccm/issues/98))
+-   Support analysis on pure event ports
+    ([\#57](https://github.com/smaccm/smaccm/issues/57))
+-   Support AADL data subranges in AGREE
+    ([\#76](https://github.com/smaccm/smaccm/issues/76))
+-   Add ability for AGREE to access AADL property constants
+    ([\#77](https://github.com/smaccm/smaccm/issues/77))
+-   Update model checker to Jkind v4.0.1
+    ([\#83](https://github.com/smaccm/smaccm/issues/83))
+
+### Issues Addressed:
+
+-   Add case handling type evaluation of enumerations as data
+    subcomponent types
+    ([\#124](https://github.com/smaccm/smaccm/issues/124))
+-   Refactor AgreeScopeProvider to fix scoping omissions
+    ([\#110](https://github.com/smaccm/smaccm/issues/110) &
+    [\#12](https://github.com/smaccm/smaccm/issues/12))
+-   Fix erroneous typing of properties
+    ([\#74](https://github.com/smaccm/smaccm/issues/74))
+-   Fix problem scoping NodeDef from other packages
+    ([\#78](https://github.com/smaccm/smaccm/issues/78))
+-   Fix spurious validation errors from re-used ids in linearization and
+    record definitions
+    ([\#102](https://github.com/smaccm/smaccm/issues/102))
+-   Disallow property statements in annex libraries
+    ([\#103](https://github.com/smaccm/smaccm/issues/103))
+-   Allow executing AGREE analysis and TCG from graphical editor
+    ([\#105](https://github.com/smaccm/smaccm/issues/105))
+-   Subrange type predicates should be obligations, not assertions
+    ([\#96](https://github.com/smaccm/smaccm/issues/96))
+-   Fix incorrect references to figures in AGREE documentation
+    ([\#88](https://github.com/smaccm/smaccm/issues/88))
+-   Fix missing variables in counter example views
+    ([\#75](https://github.com/smaccm/smaccm/issues/75))
+-   Serialization fixes
+    ([\#84](https://github.com/smaccm/smaccm/issues/84))
+-   Fix scoping of enumerators
+    ([\#81](https://github.com/smaccm/smaccm/issues/81))
+-   Fix 'Check Realizability' analysis causes Xtext exception (and
+    possible crash) ([\#79](https://github.com/smaccm/smaccm/issues/79))
+
+### Known Issues:
+
+-   AGREE does not support feature groups in AGREE assign statements
+    ([\#119](https://github.com/smaccm/smaccm/issues/119))
+-   AGREE does not support AADL property record types
+    ([\#114](https://github.com/smaccm/smaccm/issues/114))
+-   AGREE does not support AADL properties of type aadlenumeration
+    ([\#113](https://github.com/smaccm/smaccm/issues/113))
+

--- a/fm-workbench/resolute/com.rockwellcollins.atc.resolute.analysis/src/com/rockwellcollins/atc/resolute/analysis/values/ResoluteValue.java
+++ b/fm-workbench/resolute/com.rockwellcollins.atc.resolute.analysis/src/com/rockwellcollins/atc/resolute/analysis/values/ResoluteValue.java
@@ -85,8 +85,7 @@ public abstract class ResoluteValue implements Comparable<ResoluteValue> {
 		} else if (isString() && other.isString()) {
 			return String.CASE_INSENSITIVE_ORDER.compare(getString(), other.getString());
 		} else if (isNamedElement() && other.isNamedElement()) {
-			return String.CASE_INSENSITIVE_ORDER
-					.compare(getNamedElement().getName(), other.getNamedElement().getName());
+			return String.CASE_INSENSITIVE_ORDER.compare(toString(), other.toString());
 		} else if (isSet() && other.isSet()) {
 			return Integer.compare(getSetValues().hashCode(), other.getSetValues().hashCode());
 		} else if (isRange() && other.isRange()) {


### PR DESCRIPTION
This push request is intended to resolve [Issue 129](https://github.com/smaccm/smaccm/issues/129).

While the problem may be a bit tricky, the fix for this problem is simple as the toString() method on NamedElementValue handles the construction of the qualified name for instances.