### PR TITLE
Fix comparison of NamedElement instances

### DIFF
--- a/fm-workbench/resolute/com.rockwellcollins.atc.resolute.analysis/src/com/rockwellcollins/atc/resolute/analysis/values/ResoluteValue.java
+++ b/fm-workbench/resolute/com.rockwellcollins.atc.resolute.analysis/src/com/rockwellcollins/atc/resolute/analysis/values/ResoluteValue.java
@@ -85,8 +85,7 @@ public abstract class ResoluteValue implements Comparable<ResoluteValue> {
 		} else if (isString() && other.isString()) {
 			return String.CASE_INSENSITIVE_ORDER.compare(getString(), other.getString());
 		} else if (isNamedElement() && other.isNamedElement()) {
-			return String.CASE_INSENSITIVE_ORDER
-					.compare(getNamedElement().getName(), other.getNamedElement().getName());
+			return String.CASE_INSENSITIVE_ORDER.compare(toString(), other.toString());
 		} else if (isSet() && other.isSet()) {
 			return Integer.compare(getSetValues().hashCode(), other.getSetValues().hashCode());
 		} else if (isRange() && other.isRange()) {


### PR DESCRIPTION
This push request is intended to resolve [Issue 129](https://github.com/smaccm/smaccm/issues/129).

While the problem may be a bit tricky, the fix for this problem is simple as the toString() method on NamedElementValue handles the construction of the qualified name for instances.