### PR TITLE
Fix Issue 167: Null pointer exception in Resolute instance evaluation

### DIFF
--- a/fm-workbench/resolute/com.rockwellcollins.atc.resolute.analysis/src/com/rockwellcollins/atc/resolute/analysis/execution/ResoluteBuiltInFnCallEvaluator.java
+++ b/fm-workbench/resolute/com.rockwellcollins.atc.resolute.analysis/src/com/rockwellcollins/atc/resolute/analysis/execution/ResoluteBuiltInFnCallEvaluator.java
@@ -798,7 +798,7 @@ public class ResoluteBuiltInFnCallEvaluator {
 
 	private static boolean isInstanceOf(ComponentInstance instance, NamedElement declarative) {
 		ComponentClassifier cc = instance.getComponentClassifier();
-		if (cc.equals(declarative)) {
+		if (cc != null && cc.equals(declarative)) {
 			return true;
 		}
 

--- a/models/Microwave/Microwave_SEng5861.aadl
+++ b/models/Microwave/Microwave_SEng5861.aadl
@@ -275,11 +275,7 @@ system Microwave_Control
 		right_digit : out data port Base_Types::Integer; 
 					
 	annex agree {** 
-<<<<<<< HEAD
-			
 		eq ctime : int = (left_digit * 60) + (middle_digit * 10) + right_digit;
-=======
->>>>>>> develop
 		
 		guarantee "heating_element_on implies door_closed_sensor" : 
 			true ;  
@@ -288,11 +284,7 @@ system Microwave_Control
 			true; 
 					
 		guarantee "time to cook = 0 implies heating_element_off" : 
-<<<<<<< HEAD
 			ctime = 0 => not heating_element_on; 
-=======
-			true; 
->>>>>>> develop
 		
 			
 	**};	

--- a/models/Microwave/std.aadl
+++ b/models/Microwave/std.aadl
@@ -73,13 +73,13 @@ annex agree {**
 	node WithinN(evt: bool, i: bool, n: int) returns (o: bool);
 	var
 		after_event: bool; 
-		time: int; 
+		time_val: int; 
 	let
 		after_event = if i then false else if evt then true else 
 			(false -> pre(after_event)); 
-		time = if i then 0 else 
-				(0 -> pre(time)) + if after_event then 1 else 0;
-		o = time <= n;
+		time_val = if i then 0 else 
+				(0 -> pre(time_val)) + if after_event then 1 else 0;
+		o = time_val <= n;
 	tel;
 
 	node While(i: bool) returns (o: bool);


### PR DESCRIPTION
Fix null pointer exception by guarding equality method in Resolute instance evaluation.

This pull request is intended to resolve [Issue 167](https://github.com/smaccm/smaccm/issues/167).