### PR TITLE
1036 no more emf index retrieval

### DIFF
--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/ast/AgreeASTBuilder.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/ast/AgreeASTBuilder.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
+import org.osate.aadl2.Aadl2Package;
 import org.osate.aadl2.AadlBoolean;
 import org.osate.aadl2.AadlInteger;
 import org.osate.aadl2.AadlPackage;
@@ -54,10 +55,9 @@ import org.osate.aadl2.Subcomponent;
 import org.osate.aadl2.instance.ComponentInstance;
 import org.osate.aadl2.instance.FeatureCategory;
 import org.osate.aadl2.instance.FeatureInstance;
-import org.osate.aadl2.modelsupport.resources.OsateResourceUtil;
+import org.osate.aadl2.modelsupport.scoping.Aadl2GlobalScopeUtil;
 import org.osate.aadl2.properties.PropertyDoesNotApplyToHolderException;
 import org.osate.annexsupport.AnnexUtil;
-import org.osate.xtext.aadl2.properties.util.EMFIndexRetrieval;
 import org.osate.xtext.aadl2.properties.util.PropertyUtils;
 
 import com.rockwellcollins.atc.agree.agree.AADLEnumerator;
@@ -699,7 +699,7 @@ public class AgreeASTBuilder extends AgreeSwitch<Expr> {
 
 //		Set<AgreeVar> destinationSet = new HashSet<>();
 
-		Property commTimingProp = EMFIndexRetrieval.getPropertyDefinitionInWorkspace(OsateResourceUtil.getResourceSet(),
+		Property commTimingProp = Aadl2GlobalScopeUtil.get(compInst, Aadl2Package.eINSTANCE.getProperty(),
 				"Communication_Properties::Timing");
 		List<AgreeAADLConnection> agreeConns = new ArrayList<>();
 		for (Connection conn : connections) {

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.codegen/META-INF/MANIFEST.MF
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.codegen/META-INF/MANIFEST.MF
@@ -13,7 +13,8 @@ Require-Bundle: org.eclipse.ui,
  org.osate.annexsupport,
  org.osate.xtext.aadl2.properties;bundle-version="1.0.0",
  org.eclipse.core.resources;bundle-version="3.9.1",
- org.eclipse.swt
+ org.eclipse.swt,
+ org.osate.aadl2.modelsupport
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Import-Package: com.rockwellcollins.atc.agree.analysis.handlers,

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.codegen/src/com/rockwellcollins/atc/agree/codegen/handlers/MATLABFunctionHandler.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.codegen/src/com/rockwellcollins/atc/agree/codegen/handlers/MATLABFunctionHandler.java
@@ -28,10 +28,10 @@ import org.osate.aadl2.PropertyAssociation;
 import org.osate.aadl2.StringLiteral;
 import org.osate.aadl2.instance.SystemInstance;
 import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.scoping.Aadl2GlobalScopeUtil;
 import org.osate.aadl2.properties.PropertyNotPresentException;
 import org.osate.annexsupport.AnnexUtil;
 import org.osate.ui.dialogs.Dialog;
-import org.osate.xtext.aadl2.properties.util.EMFIndexRetrieval;
 import org.osate.xtext.aadl2.properties.util.PropertyUtils;
 
 import com.rockwellcollins.atc.agree.agree.AgreePackage;
@@ -230,7 +230,7 @@ public class MATLABFunctionHandler extends ModifyingAadlHandler {
 	}
 
 	private ModelInfo getMatlabExportInfo(ComponentType ct) {
-		Property prop = EMFIndexRetrieval.getPropertyDefinitionInWorkspace(ct, "Source_Text");
+		Property prop = Aadl2GlobalScopeUtil.get(ct, Aadl2Package.eINSTANCE.getProperty(), "Source_Text");
 		try {
 			ListValue lv = (ListValue) PropertyUtils.getSimplePropertyListValue(ct, prop);
 			String str1 = readPathFromAADLProperty(getStringElement(lv, 0));
@@ -270,7 +270,7 @@ public class MATLABFunctionHandler extends ModifyingAadlHandler {
 	}
 
 	private ListValue getOrCreateSourceText(ComponentType ct) {
-		Property prop = EMFIndexRetrieval.getPropertyDefinitionInWorkspace(ct, "Source_Text");
+		Property prop = Aadl2GlobalScopeUtil.get(ct, Aadl2Package.eINSTANCE.getProperty(), "Source_Text");
 
 		try {
 			// Try to find existing property association

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree/src/com/rockwellcollins/atc/agree/AgreeAADLPropertyUtils.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree/src/com/rockwellcollins/atc/agree/AgreeAADLPropertyUtils.java
@@ -3,19 +3,19 @@ package com.rockwellcollins.atc.agree;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.osate.aadl2.Aadl2Package;
 import org.osate.aadl2.EnumerationLiteral;
 import org.osate.aadl2.ListValue;
 import org.osate.aadl2.NamedElement;
 import org.osate.aadl2.Property;
 import org.osate.aadl2.PropertyExpression;
-import org.osate.aadl2.modelsupport.resources.OsateResourceUtil;
-import org.osate.xtext.aadl2.properties.util.EMFIndexRetrieval;
+import org.osate.aadl2.modelsupport.scoping.Aadl2GlobalScopeUtil;
 import org.osate.xtext.aadl2.properties.util.PropertyUtils;
 
 public class AgreeAADLPropertyUtils {
 
 	public static String getPropertyEnumString(NamedElement namedEl, String property) {
-		Property prop = EMFIndexRetrieval.getPropertyDefinitionInWorkspace(OsateResourceUtil.getResourceSet(),
+		Property prop = Aadl2GlobalScopeUtil.get(namedEl, Aadl2Package.eINSTANCE.getProperty(),
 				property);
 		EnumerationLiteral lit = PropertyUtils.getEnumLiteral(namedEl, prop);
 		return lit.getName();
@@ -24,7 +24,7 @@ public class AgreeAADLPropertyUtils {
 	public static List<PropertyExpression> getPropertyList(NamedElement namedEl, String property) {
 
 		List<PropertyExpression> els = new ArrayList<>();
-		Property prop = EMFIndexRetrieval.getPropertyDefinitionInWorkspace(OsateResourceUtil.getResourceSet(),
+		Property prop = Aadl2GlobalScopeUtil.get(namedEl, Aadl2Package.eINSTANCE.getProperty(),
 				property);
 		ListValue listExpr = (ListValue) PropertyUtils.getSimplePropertyListValue(namedEl, prop);
 		for (PropertyExpression propExpr : listExpr.getOwnedListElements()) {

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree/src/com/rockwellcollins/atc/agree/linking/AgreeLinkingService.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree/src/com/rockwellcollins/atc/agree/linking/AgreeLinkingService.java
@@ -22,9 +22,9 @@ import org.osate.aadl2.Element;
 import org.osate.aadl2.PropertyValue;
 import org.osate.aadl2.UnitLiteral;
 import org.osate.aadl2.UnitsType;
+import org.osate.aadl2.modelsupport.scoping.Aadl2GlobalScopeUtil;
 import org.osate.aadl2.util.Aadl2Util;
 import org.osate.xtext.aadl2.properties.linking.PropertiesLinkingService;
-import org.osate.xtext.aadl2.properties.util.EMFIndexRetrieval;
 
 import com.rockwellcollins.atc.agree.agree.ConnectionStatement;
 import com.rockwellcollins.atc.agree.agree.EnumStatement;
@@ -68,7 +68,7 @@ public class AgreeLinkingService extends PropertiesLinkingService {
 			}
 
 			// This code will only link to objects in the projects visible from the current project
-			Iterable<IEObjectDescription> allObjectTypes = EMFIndexRetrieval.getAllEObjectsOfTypeInWorkspace(context,
+			Iterable<IEObjectDescription> allObjectTypes = Aadl2GlobalScopeUtil.getAllEObjectDescriptions(context,
 					reference.getEReferenceType());
 
 			String contextProject = context.eResource().getURI().segment(1);
@@ -137,7 +137,7 @@ public class AgreeLinkingService extends PropertiesLinkingService {
 	private static UnitLiteral findUnitLiteral(Element context, String name) {
 		// TODO: Scope literals by type, but how to do we know the type of an
 		// expression?
-		for (IEObjectDescription desc : EMFIndexRetrieval.getAllEObjectsOfTypeInWorkspace(UNITS_TYPE)) {
+		for (IEObjectDescription desc : Aadl2GlobalScopeUtil.getAllEObjectDescriptions(context, UNITS_TYPE)) {
 			UnitsType unitsType = (UnitsType) EcoreUtil.resolve(desc.getEObjectOrProxy(), context);
 			UnitLiteral literal = unitsType.findLiteral(name);
 			if (literal != null) {

--- a/fm-workbench/releng/fm-workbench.build/modules/.settings/org.eclipse.core.resources.prefs
+++ b/fm-workbench/releng/fm-workbench.build/modules/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/fm-workbench/resolute/com.rockwellcollins.atc.resolute/src/com/rockwellcollins/atc/resolute/linking/ResoluteLinkingService.java
+++ b/fm-workbench/resolute/com.rockwellcollins.atc.resolute/src/com/rockwellcollins/atc/resolute/linking/ResoluteLinkingService.java
@@ -15,9 +15,9 @@ import org.osate.aadl2.Aadl2Package;
 import org.osate.aadl2.PropertyValue;
 import org.osate.aadl2.UnitLiteral;
 import org.osate.aadl2.UnitsType;
+import org.osate.aadl2.modelsupport.scoping.Aadl2GlobalScopeUtil;
 import org.osate.aadl2.util.Aadl2Util;
 import org.osate.xtext.aadl2.properties.linking.PropertiesLinkingService;
-import org.osate.xtext.aadl2.properties.util.EMFIndexRetrieval;
 
 import com.rockwellcollins.atc.resolute.resolute.ClaimArg;
 import com.rockwellcollins.atc.resolute.resolute.FnCallExpr;
@@ -53,7 +53,7 @@ public class ResoluteLinkingService extends PropertiesLinkingService {
 			}
             return getIndexedObject(context, reference, name);
         }
-        
+
         if(context instanceof QuantArg) {
             return getIndexedObject(context, reference, name);
         }
@@ -63,10 +63,10 @@ public class ResoluteLinkingService extends PropertiesLinkingService {
             if (e != null) {
                 return e;
             }
-            
-			Iterable<IEObjectDescription> allObjectTypes = EMFIndexRetrieval.getAllEObjectsOfTypeInWorkspace(context,
+
+			Iterable<IEObjectDescription> allObjectTypes = Aadl2GlobalScopeUtil.getAllEObjectDescriptions(context,
 					reference.getEReferenceType());
-            
+
             URI contextUri = context.eResource().getURI();
             String contextProject = contextUri.segment(1);
             for (IEObjectDescription eod : allObjectTypes) {
@@ -81,7 +81,7 @@ public class ResoluteLinkingService extends PropertiesLinkingService {
                     }
                 }
             }
-            
+
             e = getFromScope(context, reference, name);
             if (e != null) {
                 return e;
@@ -119,15 +119,14 @@ public class ResoluteLinkingService extends PropertiesLinkingService {
     private static UnitLiteral getUnitLiteral(EObject context, String name) {
         // TODO: Scope literals by type, but how to do we know the type of an
         // expression?
-		for (IEObjectDescription desc : EMFIndexRetrieval.getAllEObjectsOfTypeInWorkspace(context, UNITS_TYPE)) {
+		for (IEObjectDescription desc : Aadl2GlobalScopeUtil.getAllEObjectDescriptions(context, UNITS_TYPE)) {
             UnitsType unitsType = (UnitsType) EcoreUtil.resolve(desc.getEObjectOrProxy(), context);
             UnitLiteral literal = unitsType.findLiteral(name);
             if (literal != null) {
                 return literal;
             }
         }
-
         return null;
     }
-    
+
 }


### PR DESCRIPTION
Fixes #164
This branch has the changes for using Aadl2GlobalScopeUtil instead of EMFIndexRetrieval. I fixed this in Resolute and in Agree.
It relates to issue osate/osate2#1036