### PR TITLE
TCG: moved main menu out from under AGREE and placed it under OSATE

### DIFF
--- a/fm-workbench/tcg/com.rockwellcollins.atc.tcg/plugin.xml
+++ b/fm-workbench/tcg/com.rockwellcollins.atc.tcg/plugin.xml
@@ -57,11 +57,11 @@
    <extension
          point="org.eclipse.ui.menus">
       <menuContribution
-            locationURI="menu:org.eclipse.ui.main.menu?after=additions">
+            locationURI="menu:org.osate.ui.osateMenu?after=additions">
          <menu
-               label="AGREE"
+               label="Test Case Generation"
                mnemonic="g"
-               id="com.rockwellcollins.atc.agree.analysis.menus.main">
+               id="com.rockwellcollins.atc.tcg.menus.main">
            <separator
                  name="com.rockwellcollins.atc.tcg.separator1"
    			  visible="true">
@@ -109,8 +109,8 @@
             allPopups="false"
             locationURI="popup:org.osate.xtext.aadl2.ui.outline?after=additions">
          <menu
-               id="com.rockwellcollins.atc.agree.analysis.menus.main"
-               label="Test Case Generator"
+               id="com.rockwellcollins.atc.tcg.menus.outline"
+               label="Test Case Generation"
                mnemonic="g">
            <command
                   commandId="tcg.commands.generateTestsSingleLayer"


### PR DESCRIPTION
The main menu items for Test Case Generation are placed under the AGREE menu on the OSATE menubar.  The AGREE menu is being moved under the Analyses menu, and that location is not appropriate for TCG.  Instead, I'm moving the TCG menu items under the OSATE menu on the main menubar.  The TCG popup menu in the options pane is not changing since it was never under the popup AGREE menu there.

The only file that was modified for this change is plugin.xml.