### PR TITLE
Agree menu

### DIFF
--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/plugin.xml
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/plugin.xml
@@ -100,7 +100,7 @@
       </menuContribution>
       <menuContribution
             allPopups="false"
-            locationURI="menu:org.eclipse.ui.main.menu?after=additions">
+            locationURI="menu:org.osate.ui.analysesMenu?after=additions">
          <menu
                id="com.rockwellcollins.atc.agree.analysis.menus.main"
                label="AGREE"
@@ -169,7 +169,7 @@
       </menuContribution>
       <menuContribution
             allPopups="false"
-            locationURI="popup:org.osate.xtext.aadl2.ui.outline?after=additions">
+            locationURI="popup:org.osate.ui.analysesOutlinePopup?after=additions">
          <menu
                id="com.rockwellcollins.atc.agree.analysis.popups.main"
                label="AGREE"

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.codegen/plugin.xml
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.codegen/plugin.xml
@@ -17,7 +17,7 @@
    <extension
          point="org.eclipse.ui.menus">
       <menuContribution
-            locationURI="menu:org.eclipse.ui.main.menu?after=additions">
+            locationURI="menu:org.osate.ui.analysesMenu?after=additions">
          <menu
                label="AGREE"
                mnemonic="g"
@@ -48,7 +48,7 @@
       </menuContribution>
       <menuContribution
             allPopups="false"
-            locationURI="popup:org.osate.xtext.aadl2.ui.outline?after=additions">
+            locationURI="popup:org.osate.ui.analysesOutlinePopup?after=additions">
          <menu
                id="com.rockwellcollins.atc.agree.analysis.popups.main"
                label="AGREE"

--- a/fm-workbench/tcg/com.rockwellcollins.atc.tcg/plugin.xml
+++ b/fm-workbench/tcg/com.rockwellcollins.atc.tcg/plugin.xml
@@ -57,11 +57,11 @@
    <extension
          point="org.eclipse.ui.menus">
       <menuContribution
-            locationURI="menu:org.eclipse.ui.main.menu?after=additions">
+            locationURI="menu:org.osate.ui.osateMenu?after=additions">
          <menu
-               label="AGREE"
+               label="Test Case Generation"
                mnemonic="g"
-               id="com.rockwellcollins.atc.agree.analysis.menus.main">
+               id="com.rockwellcollins.atc.tcg.menus.main">
            <separator
                  name="com.rockwellcollins.atc.tcg.separator1"
    			  visible="true">
@@ -109,8 +109,8 @@
             allPopups="false"
             locationURI="popup:org.osate.xtext.aadl2.ui.outline?after=additions">
          <menu
-               id="com.rockwellcollins.atc.agree.analysis.menus.main"
-               label="Test Case Generator"
+               id="com.rockwellcollins.atc.tcg.menus.outline"
+               label="Test Case Generation"
                mnemonic="g">
            <command
                   commandId="tcg.commands.generateTestsSingleLayer"


### PR DESCRIPTION
I moved the AGREE menu in the main OSATE menubar to sit under the Analyses menu header.  Similarly in the Outline popup menu, the AGREE menu now sits under the Analyses menu header.  The AGREE popup menu in the AADL text editor has not been modified since there is no Analyses menu header there.

The following two file were modified to make this change:
com.rockwellcollins.atc.agree.analysis\plugin.xml
com.rockwellcollins.atc.agree.codegen\plugin.xml