### PR TITLE
Resolute menu

### DIFF
--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/plugin.xml
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/plugin.xml
@@ -100,7 +100,7 @@
       </menuContribution>
       <menuContribution
             allPopups="false"
-            locationURI="menu:org.eclipse.ui.main.menu?after=additions">
+            locationURI="menu:org.osate.ui.analysesMenu?after=additions">
          <menu
                id="com.rockwellcollins.atc.agree.analysis.menus.main"
                label="AGREE"
@@ -169,7 +169,7 @@
       </menuContribution>
       <menuContribution
             allPopups="false"
-            locationURI="popup:org.osate.xtext.aadl2.ui.outline?after=additions">
+            locationURI="popup:org.osate.ui.analysesOutlinePopup?after=additions">
          <menu
                id="com.rockwellcollins.atc.agree.analysis.popups.main"
                label="AGREE"

--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.codegen/plugin.xml
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.codegen/plugin.xml
@@ -17,7 +17,7 @@
    <extension
          point="org.eclipse.ui.menus">
       <menuContribution
-            locationURI="menu:org.eclipse.ui.main.menu?after=additions">
+            locationURI="menu:org.osate.ui.analysesMenu?after=additions">
          <menu
                label="AGREE"
                mnemonic="g"
@@ -48,7 +48,7 @@
       </menuContribution>
       <menuContribution
             allPopups="false"
-            locationURI="popup:org.osate.xtext.aadl2.ui.outline?after=additions">
+            locationURI="popup:org.osate.ui.analysesOutlinePopup?after=additions">
          <menu
                id="com.rockwellcollins.atc.agree.analysis.popups.main"
                label="AGREE"

--- a/fm-workbench/resolute/com.rockwellcollins.atc.resolute.analysis/plugin.xml
+++ b/fm-workbench/resolute/com.rockwellcollins.atc.resolute.analysis/plugin.xml
@@ -60,18 +60,9 @@
       </menuContribution>
    
 
-       <menuContribution
-            allPopups="false"
-            locationURI="popup:org.osate.xtext.aadl2.ui.outline?after=additions">
-        	<menu id="com.rockwellcollins.atc.resolute.analysis.menus.predefined" icon="icons/claims.png" label="Predefined Theorems">	
-            	<command commandId="com.rockwellcollins.atc.resolute.analysis.commands.resolutePredefined" icon="icons/claims.png" style="push" label="Check ARINC653" id="com.rockwellcollins.atc.resolute.analysis.menus.resolutePredefined">
-					<parameter name="com.rockwellcollins.atc.resolute.analysis.theorem" value="check_arinc653_compliance"/>
-				</command>
-      		</menu>
-      </menuContribution> 
       <menuContribution
             allPopups="false"
-            locationURI="popup:org.osate.xtext.aadl2.ui.outline?after=additions">
+            locationURI="popup:org.osate.ui.analysesOutlinePopup?after=additions">
          <command
                 commandId="com.rockwellcollins.atc.resolute.analysis.commands.resolute"
                 icon="icons/claims.png"
@@ -79,6 +70,22 @@
                 mnemonic="r"
                 style="push">
          </command>
+         <menu
+               icon="icons/claims.png"
+               id="com.rockwellcollins.atc.resolute.analysis.menus.predefined"
+               label="Predefined Theorems">
+            <command
+                  commandId="com.rockwellcollins.atc.resolute.analysis.commands.resolutePredefined"
+                  icon="icons/claims.png"
+                  id="com.rockwellcollins.atc.resolute.analysis.menus.resolutePredefined"
+                  label="Check ARINC653"
+                  style="push">
+               <parameter
+                     name="com.rockwellcollins.atc.resolute.analysis.theorem"
+                     value="check_arinc653_compliance">
+               </parameter>
+            </command>
+         </menu>
       </menuContribution>
       
       <menuContribution
@@ -88,6 +95,44 @@
                commandId="com.rockwellcollins.atc.resolute.analysis.commands.rerunResolute"
                icon="icons/refresh.gif"
                label="Re-run Resolute"
+               style="push">
+         </command>
+      </menuContribution>
+      <menuContribution
+            allPopups="false"
+            locationURI="menu:org.osate.ui.analysesMenu?after=additions">
+         <command
+               commandId="com.rockwellcollins.atc.resolute.analysis.commands.resolute"
+               icon="icons/claims.png"
+               id="com.rockwellcollins.atc.resolute.analysis.menus.resolute"
+               mnemonic="r"
+               style="push">
+         </command>
+         <menu
+               icon="icons/claims.png"
+               id="com.rockwellcollins.atc.resolute.analysis.menus.predefined"
+               label="Predefined Theorems">
+            <command
+                  commandId="com.rockwellcollins.atc.resolute.analysis.commands.resolutePredefined"
+                  icon="icons/claims.png"
+                  id="com.rockwellcollins.atc.resolute.analysis.menus.resolutePredefined"
+                  label="Check ARINC653"
+                  style="push">
+               <parameter
+                     name="com.rockwellcollins.atc.resolute.analysis.theorem"
+                     value="check_arinc653_compliance">
+               </parameter>
+            </command>
+         </menu>
+      </menuContribution>
+      <menuContribution
+            allPopups="false"
+            locationURI="popup:#TextEditorContext?after=additions">
+         <command
+               commandId="com.rockwellcollins.atc.resolute.analysis.commands.resolute"
+               icon="icons/claims.png"
+               id="com.rockwellcollins.atc.resolute.analysis.menus.resolute"
+               mnemonic="r"
                style="push">
          </command>
       </menuContribution>
@@ -119,6 +164,7 @@
          point="org.eclipse.core.expressions.definitions">
       <definition
             id="com.rockwellcollins.atc.resolute.analysis.expressions.isSingleOutlineSelection">
+         <or>
          <with
                variable="selection">
             <and>
@@ -134,6 +180,10 @@
                </iterate>
             </and>
          </with>
+         <reference
+               definitionId="org.osate.xtext.aadl2.Aadl2.Editor.opened">
+         </reference>
+         </or>
       </definition>
    </extension>
    <extension

--- a/fm-workbench/tcg/com.rockwellcollins.atc.tcg/plugin.xml
+++ b/fm-workbench/tcg/com.rockwellcollins.atc.tcg/plugin.xml
@@ -57,11 +57,11 @@
    <extension
          point="org.eclipse.ui.menus">
       <menuContribution
-            locationURI="menu:org.eclipse.ui.main.menu?after=additions">
+            locationURI="menu:org.osate.ui.osateMenu?after=additions">
          <menu
-               label="AGREE"
+               label="Test Case Generation"
                mnemonic="g"
-               id="com.rockwellcollins.atc.agree.analysis.menus.main">
+               id="com.rockwellcollins.atc.tcg.menus.main">
            <separator
                  name="com.rockwellcollins.atc.tcg.separator1"
    			  visible="true">
@@ -109,8 +109,8 @@
             allPopups="false"
             locationURI="popup:org.osate.xtext.aadl2.ui.outline?after=additions">
          <menu
-               id="com.rockwellcollins.atc.agree.analysis.menus.main"
-               label="Test Case Generator"
+               id="com.rockwellcollins.atc.tcg.menus.outline"
+               label="Test Case Generation"
                mnemonic="g">
            <command
                   commandId="tcg.commands.generateTestsSingleLayer"


### PR DESCRIPTION
I moved the Resolute menus under the Analyses menu header in the Outline pane.  In addition, I added the Resolute menu items to the text editor popup context and to the main menubar under the Analyses menu header.

In order to run Resolute from the main menu and text editor, I made a minor change to the AadlHandler to capture the URI of the selected element, regardless of whether it is in the text editor or outline pane.

The following files were modified to make this change:
com.rockwellcollins.atc.resolute.analysis.handlers\AadlHandler.java
com.rockwellcollins.atc.resolute.analysis.handlers\ResoluteHandler.java
com.rockwellcollins.atc.resolute.analysis\plugin.xml