### PR TITLE
Bugfix to ensure text selection returns correct EObject

### DIFF
--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/handlers/AadlHandler.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/handlers/AadlHandler.java
@@ -33,6 +33,7 @@ import org.eclipse.xtext.ui.editor.utils.EditorUtils;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 import org.osate.aadl2.Classifier;
 import org.osate.aadl2.Element;
+import org.osate.aadl2.Realization;
 import org.osate.aadl2.modelsupport.resources.OsateResourceUtil;
 import org.osate.ge.BusinessObjectSelection;
 
@@ -147,6 +148,9 @@ public abstract class AadlHandler extends AbstractHandler {
 			TextSelection ts = (TextSelection) xtextEditor.getSelectionProvider().getSelection();
 			return xtextEditor.getDocument().readOnly(resource -> {
 				EObject e = new EObjectAtOffsetHelper().resolveContainedElementAt(resource, ts.getOffset());
+				if (e instanceof Realization) {
+					e = e.eContainer();
+				}
 				return EcoreUtil.getURI(e);
 			});
 		}


### PR DESCRIPTION
When AGREE is launched from the popup menu in the text editor, or from the toolbar or main menu when the text editor is the active pane, the selected object in the text editor is resolved via the following call (in `AadlHandler`):

`EObject eObj = EObjectAtOffsetHelper().resolveContainedElementAt(resource, ts.getOffset());`

However, this returns an `EObject` that's an instance of `Realization`, which is NOT a `NamedElement`.  For verifying single layers in AGREE, this is not a problem and AGREE runs fine. However, when verifying all layers, this is a problem because in `VerifyHandler`, there is an attempt to cast the `EObject` to a `NamedElement`, which throws an exception.

This commit is a simple fix, which adds the following to `AadlHandler` to check if the `EObject` is a `Realization`, and if so, instead grab the `EObject`'s container, which is what should be returned (as is the case when AGREE is launched from the outline pane):

```
if (e instanceof Realization) {
	e = e.eContainer();
}
```