### PR TITLE
modification to record correct analysis status

### DIFF
--- a/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/saving/AgreeFileUtil.java
+++ b/fm-workbench/agree/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/saving/AgreeFileUtil.java
@@ -222,16 +222,19 @@ public class AgreeFileUtil {
 					}
 				}
 
-				// Set the status for this analysis based on the status of each sub-analysis
-				MultiStatus status = new MultiStatus();
-				for (AgreeLogResult analysis : logResult.getAnalyses()) {
-					status.add(Status.valueOf(analysis.getResult().toUpperCase()));
-				}
-				logResult.setResult(status.getOverallStatus().toString());
-
 				// Set timestamp and hashcode of the current JKind result
 				logResult.setTimestamp(agreeLogResult.getTimestamp());
 				logResult.setHashcode(agreeLogResult.getHashcode());
+
+				// Set the status for this analysis based on the status of each sub-analysis
+				// that has the same timestamp as this analysis
+				MultiStatus status = new MultiStatus();
+				for (AgreeLogResult analysis : logResult.getAnalyses()) {
+					if (analysis.getTimestamp() >= logResult.getTimestamp()) {
+						status.add(Status.valueOf(analysis.getResult().toUpperCase()));
+					}
+				}
+				logResult.setResult(status.getOverallStatus().toString());
 
 				break;
 			}


### PR DESCRIPTION
Quick fix for minor issue in AgreeCheck.  Status was not being recorded correctly when a single layer run was performed after a multi-layer run.