### PR TITLE
Fix non-API imports in Resolute

### DIFF
--- a/fm-workbench/resolute/com.rockwellcollins.atc.resolute.agreecheck/META-INF/MANIFEST.MF
+++ b/fm-workbench/resolute/com.rockwellcollins.atc.resolute.agreecheck/META-INF/MANIFEST.MF
@@ -5,24 +5,18 @@ Bundle-SymbolicName: com.rockwellcollins.atc.resolute.agreecheck;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: com.rockwellcollins.atc.resolute.agreecheck.Activator
 Bundle-Vendor: ROCKWELLCOLLINS
-Require-Bundle: org.osate.aadl2;bundle-version="1.0.0",
- org.eclipse.ui,
+Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- com.rockwellcollins.atc.resolute.analysis,
  org.eclipse.emf.ecore,
+ org.eclipse.emf.common,
  org.eclipse.core.resources;bundle-version="3.12.0",
- org.eclipse.emf.common
+ org.osate.aadl2;bundle-version="1.0.0",
+ org.osate.annexsupport;bundle-version="1.0.0",
+ com.rockwellcollins.atc.agree;bundle-version="1.0.0",
+ com.rockwellcollins.atc.agree.analysis;bundle-version="1.0.0",
+ com.rockwellcollins.atc.resolute;bundle-version="1.0.0",
+ com.rockwellcollins.atc.resolute.analysis
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: com.rockwellcollins.atc.resolute.agreecheck
 Bundle-ActivationPolicy: lazy
-Import-Package: com.rockwellcollins.atc.agree.agree,
- com.rockwellcollins.atc.agree.agree.impl,
- com.rockwellcollins.atc.agree.analysis,
- com.rockwellcollins.atc.agree.saving,
- com.rockwellcollins.atc.resolute.analysis.external,
- com.rockwellcollins.atc.resolute.validation,
- jkind.api.results,
- org.eclipse.core.resources,
- org.eclipse.xtext,
- org.osate.aadl2,
- org.osate.aadl2.instance
+Import-Package: org.eclipse.xtext

--- a/fm-workbench/resolute/com.rockwellcollins.atc.resolute.agreelib/META-INF/MANIFEST.MF
+++ b/fm-workbench/resolute/com.rockwellcollins.atc.resolute.agreelib/META-INF/MANIFEST.MF
@@ -6,19 +6,15 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: com.rockwellcollins.atc.resolute.agreelib.Activator
 Bundle-Vendor: ROCKWELLCOLLINS
 Require-Bundle: org.eclipse.ui,
+ org.eclipse.emf;bundle-version="2.6.0",
  org.eclipse.emf.common,
-  org.eclipse.core.runtime
+ org.eclipse.core.runtime,
+ org.osate.aadl2,
+ org.osate.annexsupport;bundle-version="1.0.0",
+ com.rockwellcollins.atc.agree,
+ com.rockwellcollins.atc.agree.analysis,
+ com.rockwellcollins.atc.resolute,
+ com.rockwellcollins.atc.resolute.analysis
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: com.rockwellcollins.atc.resolute.agreelib
 Bundle-ActivationPolicy: lazy
-Import-Package: com.rockwellcollins.atc.agree.agree,
- com.rockwellcollins.atc.agree.agree.impl,
- com.rockwellcollins.atc.resolute.analysis.execution,
- com.rockwellcollins.atc.resolute.analysis.external,
- com.rockwellcollins.atc.resolute.analysis.values,
- com.rockwellcollins.atc.resolute.resolute,
- com.rockwellcollins.atc.resolute.validation,
- org.eclipse.emf.ecore,
- org.osate.aadl2,
- org.osate.aadl2.instance,
- org.osate.annexsupport

--- a/fm-workbench/resolute/com.rockwellcollins.atc.resolute.stringlib/META-INF/MANIFEST.MF
+++ b/fm-workbench/resolute/com.rockwellcollins.atc.resolute.stringlib/META-INF/MANIFEST.MF
@@ -6,12 +6,10 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: com.rockwellcollins.atc.resolute.stringlib.Activator
 Bundle-Vendor: RockwellCollins
 Require-Bundle: org.eclipse.ui,
+ org.eclipse.emf;bundle-version="2.6.0",
  org.eclipse.core.runtime,
+ org.osate.aadl2,
+ com.rockwellcollins.atc.resolute,
  com.rockwellcollins.atc.resolute.analysis
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: StringLib
-Import-Package: com.rockwellcollins.atc.resolute.analysis.external,
- com.rockwellcollins.atc.resolute.resolute,
- com.rockwellcollins.atc.resolute.validation,
- org.eclipse.emf.ecore,
- org.osate.aadl2.instance


### PR DESCRIPTION
Fix manifests to use Required Plugins instead of Imported Packages.